### PR TITLE
Rename scope to playlist-modify-public

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ RSpotify::authenticate("<your_client_id>", "<your_client_secret>")
 # config/initializers/omniauth.rb
 
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :spotify, "<your_client_id>", "<your_client_secret>", scope: 'user-read-email playlist-modify'
+  provider :spotify, "<your_client_id>", "<your_client_secret>", scope: 'user-read-email playlist-modify-public'
 end
 ```
 


### PR DESCRIPTION
Spotify's Web API has renamed the `playlist-modify` scope to `playlist-modify-public` to better describe what it allows. Even though the old one will be supported for some time, the new one is the preferred way to go.
