### PR TITLE
User#playlist support for limit, offset and private playlists

### DIFF
--- a/lib/rspotify/user.rb
+++ b/lib/rspotify/user.rb
@@ -117,10 +117,10 @@ module RSpotify
     #           playlists.first.name  #=> "Movie Soundtrack Masterpieces"
     def playlists(limit: 20, offset: 0)
       url = "users/#{@id}/playlists?limit=#{limit}&offset=#{offset}"
-      if @credentials.present?
-        json = User.oauth_get(@id, url)
-      else
+      if @credentials.nil?
         json = RSpotify.auth_get(url)
+      else
+        json = User.oauth_get(@id, url)
       end
       json['items'].map { |i| Playlist.new i }
     end


### PR DESCRIPTION
I apologize for having these two fixes in one pull request but they are related to the same part of code.

First commit adds [support for limit and offset](https://developer.spotify.com/web-api/get-list-users-playlists/#tablepress-132) for playlists.

Second commit adds checking if the user is authorized using OAuth so it sends proper headers and returns list of playlists including private ones.
