### PR TITLE
Add constraint to check if track exists before trying to initialize it

### DIFF
--- a/lib/rspotify/playlist.rb
+++ b/lib/rspotify/playlist.rb
@@ -121,7 +121,7 @@ module RSpotify
       end
 
       # Tracks removed from Spotify have 'track' key set to null
-      tracks = json['items'].map { |i| Track.new i['track'] if i['track'].present? }.compact
+      tracks = json['items'].map { |i| Track.new i['track'] unless i['track'].nil? }.compact
       @tracks_cache = tracks if limit == 100 && offset == 0
       tracks
     end


### PR DESCRIPTION
Example of removed track's hash:

``` ruby
{"added_at"=>"2013-09-20T08:14:29Z", "added_by"=>{"external_urls"=>{"spotify"=>"http://open.spotify.com/user/1158639847"}, "href"=>"https://api.spotify.com/v1/users/1158639847", "id"=>"1158639847", "type"=>"user", "uri"=>"spotify:user:1158639847"}, "track"=>nil}
```
