### PR TITLE
Fixed escaping of queries with percent-encoding reserved characters

### DIFF
--- a/lib/rspotify/base.rb
+++ b/lib/rspotify/base.rb
@@ -83,7 +83,7 @@ module RSpotify
     #
     #           RSpotify::Base.search('Arctic', 'album,artist,playlist').total #=> 2142
     def self.search(query, types, limit: 20, offset: 0, market: nil)
-      query = URI::encode query
+      query = CGI.escape query
       types.gsub!(/\s+/, '')
 
       url = "search?q=#{query}&type=#{types}"\

--- a/spec/lib/rspotify/track_spec.rb
+++ b/spec/lib/rspotify/track_spec.rb
@@ -70,7 +70,7 @@ describe RSpotify::Track do
       end
       expect(tracks)             .to be_an Array
       expect(tracks.size)        .to eq 20
-      expect(tracks.total)       .to eq 3565
+      expect(tracks.total)       .to eq 3647
       expect(tracks.first)       .to be_an RSpotify::Track
       expect(tracks.map(&:name)) .to include('Do I Wanna Know?', 'I Wanna Know', 'Never Wanna Know')
     end
@@ -86,13 +86,13 @@ describe RSpotify::Track do
         RSpotify::Track.search('Wanna Know', offset: 10)
       end
       expect(tracks.size)        .to eq 20
-      expect(tracks.map(&:name)) .to include('They Wanna Know', 'Say I Wanna Know')
+      expect(tracks.map(&:name)) .to include('They Wanna Know', 'You Wanna Know')
 
       tracks = VCR.use_cassette('track:search:Wanna Know:limit:10:offset:10') do 
         RSpotify::Track.search('Wanna Know', limit: 10, offset: 10)
       end
       expect(tracks.size)        .to eq 10
-      expect(tracks.map(&:name)) .to include('They Wanna Know')
+      expect(tracks.map(&:name)) .to include('You Wanna Know')
 
       tracks = VCR.use_cassette('track:search:Wanna Know:market:ES') do
         RSpotify::Track.search('Wanna Know', market: 'ES')

--- a/spec/vcr_cassettes/track_search_Wanna_Know.yml
+++ b/spec/vcr_cassettes/track_search_Wanna_Know.yml
@@ -231,4 +231,215 @@ http_interactions:
         +rIZvGZRRqHff/7lz/8DQABOXcHPAAA=
     http_version: '1.1'
   recorded_at: Fri, 15 Aug 2014 20:05:27 GMT
-recorded_with: VCR 2.8.0
+- request:
+    method: get
+    uri: https://api.spotify.com/v1/search?q=Wanna+Know&type=track&limit=20&offset=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      accept:
+      - '*/*; q=0.5, application/xml'
+      accept-encoding:
+      - gzip, deflate
+      user-agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - nginx
+      date:
+      - Sat, 14 Feb 2015 17:55:29 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      keep-alive:
+      - timeout=600
+      cache-control:
+      - public, max-age=7200
+      access-control-allow-headers:
+      - Accept, Authorization, Origin, Content-Type
+      access-control-allow-origin:
+      - '*'
+      access-control-max-age:
+      - '604800'
+      access-control-allow-methods:
+      - GET, POST, OPTIONS, PUT, DELETE
+      access-control-allow-credentials:
+      - 'true'
+      content-encoding:
+      - gzip
+      x-content-type-options:
+      - nosniff
+      strict-transport-security:
+      - max-age=31536000;
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAOyd6U4rSZaA/89TWPyo6VFX1Y19KanU8gKYxWzGbNOjUqzY
+        Fy/gDUyr32PeZ15sIvNSwIXM9JK2m+qipEoZ+9yTmbGc+M6JExH/+I9CYWPY
+        V+ZmsFH4pfCP8Gf4otl3Pvpzozkc3g5++fJF3bZ+Htz2hi0/+dn0Ol/G8MvA
+        qb5p/u1u5PqTX89Vt6v+utft3f/Q837ghr+CH9qtTmv4KwI/DCe37tf4Hhs/
+        ftPfGrpOfL//frpj+E619ajz8gwv3/0W/fv4ab6J/Pjq97FqtZVuu986qn/j
+        hk86N4qVjR/D9TS6ljbj63Z0LRfjazW+XsbXq+haiWUqe9F1M/68WY+uWzvx
+        9SS6bpfia/y5GktWG9F1J5bfieV34jvux/9q/9vnWGb/LLrWyvE1/r4W3/1g
+        P74eRtej+KmO4m+OYpmT+Pt6rL8eP3891lyP716PdZ7Gz3N6Hl0b9Y3C/7wq
+        HfcwdP2uav826rcH35ds+PWpOr+r5t6t635Xz3GJf6G6AS/2Lh+qzc370U27
+        fYrAw/Bm41nbP1/ddJamE2sdpKl9paxlY1UzCHbUtXvTor49jmtdN4fRD4yA
+        H1//Egrlu+cMT2lsNzzil1jZF2KlM5AwhxWiXEPAcPhKEYidZ8Zg6zCiAIiN
+        77Tet+yw+XS7V+WT9lAYzPdQkjIkGSEMcqq1IsZYb5mzxgnDhcPQCiWVtSkP
+        FW43w0MxMtczMSs80EJwgSmkBkLmrdZOIsMsJY778CXmBqUW1Msjfdd8u6rz
+        rdsXa6+rOt0ajPqt+Ien1vZLLPBLduN9brobqj9sDYbv2tBSelGs+gvf7wrQ
+        btRZ1QF+Ma7uiLu7ajVHN/r2xGl63/ej6YIvZd43w5Yp1HrdGzcZJJd/fPvM
+        Coglfsl+71eV/mnP0+35hm0NzG/dUUe7flQq8OWHUV8NW73ub9+GVMQRls89
+        ODTf23bLtOKO7VV74F798tSwW/ZNu95oDfomrsntUnlzHwazgRl632UyusZs
+        HSOGgi/4q++D0y1WOTaH+2oorre7fDPhdrP0iW8ok6byWdVTh5gqNvjttq0m
+        UYuM5If90UvxPXeVSq+wU4gBqBAB0N9e/vlt73bUVv3WMC4G8VIpt303brn7
+        396a1ttn09q5xT89SX0xUECPmUPeAa8JFIIaLbAS3knPGRFAUsQBfLlxXAqJ
+        jeW5977msYSuG//8S1bNvBo/ZmG3Qat7HUpxdng7Se7ypbgTlU7edf+4o5Xj
+        X8snWQahEstslmc1DtvxM1QPcpuIi9g47LwzFPFbHG0mG42jy3emI8VoNOLn
+        aVyuCALxcDi5rrfEUZnfqirs8NNBR5dyQ2CK2veD1wyCy4fAQHihuwFlhaFS
+        YAg5Qt44ZhHDDBrAOPcAZLDNKiDQQaihtFIwooSASFhsAphSHJ7TYB34CyAX
+        IHGdEKgIUJI6GgjUccutgcyJAIFcKiyUcoBYG3hVLwyBqVZ2ASTMbsqfSPgH
+        QsLPUSL/KDEHWmKClo+WeHVoSWQTnFzu4cnj+Y3XZ5OD3a+7AZTyoGWKyrdo
+        OVVsmWjJF0VLKAglMgxlQmipJRHce0sU1BJL4zEQ2BHO+ArQMqtm5kTLecOC
+        r2xGsfFhLMfeMu3Hkzv6zoocXC1kS2ZzVldJn+TkuEJHRUVKZ4939eJ2D7sK
+        2cpNnylq34+TMwgunz6Zo8oiwDyF0CvtLIPKOSiUoV4iSGxw9LW1fK30KaCB
+        mDGEALJeWiKN4ZZhwByg3kopJDBUY7hO+rTaAq0NAWF4osyEYoKEIcgDjQLh
+        CDPGBGi2aUQ8nT4P+9eqG+DnpNUb5iHP7Ga8VvK8rRaP6nuX2wfAs0vfQ/Tm
+        arC5BPJM1ptAnlMFn0v/vNW2hbLq25zQmfnKi0Hn5wCywgFkZjDFkDKKlwSm
+        jb2fipL+BOlPIPxHVxf2NB26Xb3rbB0WL0Xz9tIO9H6lki/smazyXdhzmtiM
+        bDoq3MdsepPFpuDl+7nQVBPItGbUeg2RMQQ6B2wY+KKoJ4LIeQM55dSmoyld
+        NOqZUTFrQdNl2ZQ/szVZFYjyCawcfb0v6zN9rq52dlVd2WObG0RT1CYMm9MF
+        lw+iUDPHPcKMhr4oaABRAonjQCHpOYESWYA9sOnRvZWAqMFEYaGdwcIQLaO5
+        8eCuGkYwCEhqvFSMSgTWCaKheJhz1kBNvHJea2S4dKF0hAGCm+BhW46ZVwuD
+        6MkPpUK93bsv7KpOSgxuNhLNbsfrJFH8eHroYGk4Ob25PxhfXh0+XNwML/KT
+        aIrehJmFqYLPxb/bc/kYNPtl52bQz5FiuSPF7KFQgRBjyyLO+u4OjGATooTY
+        5JJwk2/Cg6+8vX0zhgP/UKmV74e9TjsXbqaofIubU8Vmwc3XcdDCT4UTZVu9
+        wqZtDdO4E73U3ZzT7YBYLwVHHHkKLFeCMGVlwE3OAcFhcFFcK47SwROiBckz
+        q45WTJ7vc2vyZ9XksAbfTX2k5dD83q9XlPV4wO661fr27c7jYaVxfjY5gfqh
+        nT/rMVnt+2FpBsHlk57ABAAdxcoI1JZgKjTBBAfOYpRiCKXSCHu03qxHp5DF
+        QljGIVTeSuyp9Eoh5R2nDCNuPWSSyXWSnkAwYB5RHCrHuFMEEKMwl0xoCcM3
+        3AX8tGjxkGPjtrDTLdQ7vZsU5Jgx/TGzFa814rg5IUcVUrsc7Bm6g2yv3bjX
+        y5jrTtab4DpNFXyZ63b93qDTCnWVL+KY+cq5Mh//iNZ5ZrqCAohXg2jeieZa
+        rQ4xA4iBldEVOm18HY2uJqK406XGDVtyR3V2ctFVisq3dDVVbG66Om9Ongmr
+        1O8pa9RgWNhvjV3hqBlaqXXt22ZLFaDkIo2+4EvwbT76QgQhiaW1nBAJGfCO
+        ICqDd8+jnMcw/DhIrH5l69/T10sgeD76yqrDOekr1ORtKKmoSX9OTH+4eYVl
+        UiL21uJRubR93bjY7NTrzdbZdm2UPy0yWW1C8GK64PIpkROFqKHhf6aNgZph
+        4qEmzBlmKBRcA8+dgOlhrlVQIhNWeyi8wQFcueXeI+AA0wpwJLVm3DjJqHPr
+        pESHLDPACOIJQR45IYFnDHDPnBQCIU4MowjThSlx2/U7qluo9kYDV6gFO+36
+        gx8LZ732zwWRBxuzm/U6sZFVKvfwYNwfly73++N2U1mK+UN+bEzR+76HTRd8
+        ro3TpiucOmWaoRbykWP2W3/XPpdY1nC8c9G5LPb0XvGm0S7hfvWy2lxCUkCK
+        3vdlPV3wuawPeq4deKTnuq2HfGWd/darKmu8L87LFVwv1XeOS1/vyjcX9erx
+        9hLC3sl6E0aOqYLPZV3u9d2kUOzavrvPGf/OfOvPHIwPx0qz52AISvmycjAq
+        m+eCQwIwkatLDuZ7l+6siu3+juiPQP3WPd60yUW+iHiyyncR8Wlis/hsrzy2
+        y96oUHLDUCrBcdvv6cIPhdPITSucuM4r67ikzAwBJNcuVLbQ0ZJjzIlkyGkp
+        IGMcSBaIUFKhspKGX249Z4A8o8rW56JNMTUpRma55iXBsOQwKQnGZBYzcrY2
+        Nws172vokU/o4fnJTflKmiN1uH+X281KUft+sJxBcAVpFwALGcjPKRycKQUo
+        IwpgBrkHmGuDCadYSrLe1WceMMYkooxSwSBEjgLHlPMWKAckslwFL4tKvE43
+        iwZ3LxSQ1hApZ7jS1kBLpWGSW+GRAVhjSJBZ3M3qOzV0g2Gh2hrmSrvIbsef
+        aRd/iLSLT/s/k/2fPZlCMvFihZaVTAEoXxk6MjPswz2+97i32X/Qfrs46e6L
+        Yi50TFH5Fh2nis0b7k+jQ7ZoBF/bYH6V5ihwYkBEbYmQWjAhgQWCEe29tsD6
+        jAj+y2q2+egwq1Y+0yfe9eRXrmBwAleURPF4VZvI46Z+HBe/9m5G/dJ48zp/
+        umyK2oQkiumCK+A2BhVhAmpEHeKKS4h4tDIfY2cEhqFzKCokT88NWAW3Ecws
+        pNw5QKUEXmqHLbXEy2jJlgp/IxVIjqctJlsJtwX/3lMjKEJMRXDLQsloSASI
+        kus4w0oJZ6FMW0s2ndtKEbP1fKEambtmtHZ9qLoqD8BlN+i15lN0G6RZAgRc
+        n3aqHUIvL2vjO7OEfIpkvQn5FFMFn+thlvKfOaki871XFa5FZdklw+Prg/1m
+        9ahZL3fs4LibZw+8p9JO0ZvggU4VfFmao8YtWyj2TXPUdsOcxZ394n+SHJa3
+        Q+TsmSxMILm0lWn18woMUMUwX92yNHR2fz45PGpXR86ddA6uRtedg9NBvkyW
+        ZJXvMlmmic2dyXLZG6XhLREL4i02iEmGNGfUEAuMCLRrLI+SUsKQKrCgXHhI
+        aTrevtx5zvyUjJr53DJhcUvwIVYeLBO62WmDdk/Qubk/nFzvXRer5it/5Lmh
+        O0Vtwoz5dMEZoBvL+XJSXIBbS7kBGClhrPbUCewU8pxjLb11RgPI0uKSs0E3
+        kvM9lFPEWosC5xomDeKSaUEhdYwgRYQHCmKumUoLTK4EupHCyCsArDIYKCGw
+        ZRALIWg0m6MsVNCHwsuIKk+D7pqzo8coPZCInxAAqPCXOB8F/lce7s5u02sN
+        nJraZqsyeJBnt9vjLQ6bje3BfX0JgdNkvQmB06mCz1WxaW3LFb5VSM4IauZb
+        f07cf6ChZHY4lZygZS1iq28eHdcAgzBacrsqOIX7j1uXkDc6N2f1QcV9neyV
+        d2uTXHCaovItnE4VmwlOfTxVf+JUuz2ZIQaLXypnPkj1jkKoGJdhBJRKCwm9
+        gSwwqwVSYocsB8hjB9IhFb7cej5KzaqiD0OpfxSjsl5DsqKtu+DhvTjeOtuH
+        Z/viZOdiv3dRlYf5t+5KVvt+uJxBcBYa5XNBFkYOKAMssMIZJrDCGEHsqYnm
+        oRFlEjLrVM6NY+elUeG5Ms5hz4l3wERPqBTzEulo4p4JaKI9bsVaTw/QmHiN
+        sMXeOYYV1NRL6xV1VjqkHWcYS63d4lP3JXdd2Or1AwT1zSQPgWa347WmRLvx
+        XoXunu8eHuC7o9LusLHZGV4uISU6WW+CgzdV8CVz4qdGtzXMx57Z77uyBN3P
+        BImV4v3nGJw9Bs+ePsEoSMH47zB0thDzzgkEGCKC5OpCzLuHjevigZ9cg315
+        dMFua1v3zYRdEOcJMSerfBdiniY2e+LtthsWTntT48x00SxbDy0SFIR6IIy5
+        AARUSuSER057Qj0DRAoqgE5H+EUJPqt6Pgl+Tutxuhbrsdp4Mi5/HZ1OhvtX
+        j3hbPnYvhqi/e93Iv8YxWW3CQDhdcPlJHA56wg0XiAff2RtNCFSKS0k1xRBL
+        K5mimqSGbleUxAGp0ZwSTERgY0eVxlYbraS0XFhBg4cBgdVr3XwXhmdAgnMq
+        hUZSQ68BsUhaF82QifBEjHHk5OJrHOvVYuXy4izXcsbMFrxOdkcX3e7D8ePD
+        1tW2uNs8+qpuejdHtSXkESTrTcgjmCr4suuxbrnCab9lcsJl9jv/qeHyXzU8
+        vIXLl8023sIlIRQnJzAsAJeNGgcRrNLVwSXtXHe63XHtrD/uC4DU1dHFrT3O
+        BZcpKt/C5VSx+VZ1pWYuLBoUhhhyiV2Ue4sACEMYVZxbLSnCDElnieYwEGZW
+        UHjRdVtZlbLGg8Q+J5w+fO4COYdfvz7cV+w13ezDc7i709AM548WJ6tNiBZP
+        F1w+a0pKCNEQaa+MUZR5TpAlgeq4EJj58K3WCpj1JgxrLj1WXmlEDGEiGAan
+        FQTIYhb+Zt4KLInwaQ+1mrNmY8R0WAtLGPE+OpHIccMMIk5y7xw0PPDm4tHi
+        aHouwQQvEi7ObMjrRE6oDodsf3xxeMZ2hB3DIq20WmoJuzok633fp6YLvqSu
+        Hh4USieH5cN8xJn9yp/ZCh9o8Jg9zBmQhS1rldh2qXgSnT4GAV/dlrv46lHe
+        HJzf9x7Oa/uogW+K7vHB5zvhIVnlWxSdKjYLiqbYwrcBzkX32WVYIoOoUcBF
+        tpwDhChSREpIPPBWCoQdBzZrn90FaTSrXj5MgPPTnvzrYRR/HZeOdouqNOmf
+        uoObzevx/ZVbwuZuyWoTAp/TBVdw5q3S1EnGvZBcAsS9dlw5ToFQSiHIvBRO
+        a5u22+5qYBRowS302iisifZCQeux9p5JQyQQWBuAGdZpO86tJpE2FAZiWlpD
+        kJFKhDKyFCvEA5ACKBDxkOPweAvD6EGvUJsMm71277rlBoVhr7DVa0eHP/yl
+        4tqjB5croTa7ba+TT4G2vqUmx8U9d3+3OVYN1r8oj/PzaYre991suuBLbvP/
+        /W8+Ms1+2U8y/UAjyexkSjEUy8qjfSFTsbogKSl15c3lsCTZgbq9pjeTYz8x
+        nXzn4iarfEumU8VmIdMDN3b9Wdh00cl3Fa0gcTra3MYYbhTUKpp1D2OOgzaM
+        NJ5Kq7jj6Wy66CbEWTXzYdj049iSj29FlsmjYFtv085lfaslweHgctIgza2t
+        cm4eTVGbMFBOF1zBKbhUMU40IcZprgHGXEIVnX7LPNEUYYKURVL4tfIoJc4A
+        CaGDRkIGjXYOcwCdMtIArhjl3jHo087JWAmPYhKVjCPScOA4ptxJDpXEGjEI
+        KaUAwPClTy+oaTxa7E50z/6+cKE0mhSKhaoLYPO3PCCa3ajXOjffd8NTXtu6
+        r1bOTt32XsVO9OYSthpO0ZswNz9V8Lku9n4u1Fqm6drfz4UtMDmf+dL/5pPz
+        H3/4mB1CIcVLg9BGvXgaTCwgVK4wPLrX2d1rXRndhVv79u5k0LfV8na+8Giy
+        ynfh0Wlis0BoNTjilV68oGsv6wBcsmiAlAuhCGUCQs2VsNR7hbTxSgoEiNfE
+        emG0BBnz9QufgJtRM5/T9X9Ev3bFh2DUxsXTy0n54rozPrxT51/Hx7J3mj9O
+        mqw2IU46XXAFh2AA5RjjmggYiMsJgg3kinsDgCNIcqEZIE6lnTexGi41WGvK
+        EbQKUM0lFQ4KrJWJlp4JKwEljAsC1rrES0ETHRTCFeBSBDKVGnAkMKfeRCcH
+        KyWR1IKnF9Q0Li21blrdVqGiHl1h8yhXUDSzIX8GRT+Dop+DR1wPc4RGEVzW
+        /ldrCY1ivr2Fmr3zcnm7sYO66h5dnV3d56PSZJXvqHSa2DJDowvvfyUZR0AL
+        hJSRMlyiI9Y14gxzH6DUeO8ss9CIdCpd9HTcrJr5pNJ/D8OyTCrlzYszORmM
+        znz3/I6ivtjt1es7uak0Re37EXQGwRUsW8JUAGypATD0TW4MYZAz6wJ5cUOk
+        jRbVM+LWe2aAwI4qywzmjCKnPEFQaOStcU5Gm3JpFAVxxVqjpZRBTAjwwbVG
+        TAESgNl6rWG0IxYyCEcnoHmM08+wm0alb85nyQem2W15rWC6hye8ezC6v7k6
+        3d8ZHT9eXxz1l7D5QIreBDCdKviSTdrqO5Nz84Hs913ZdrPkUGwNH1nxTvfK
+        uKHudeue9JcQik7WmxCKnir4KhAW7WZU6Y86nV7X5ivt7Pf+9AQ+3IA9xy4F
+        AC3tkIdykVVQdMoDRmR1nkD94WpYPirK3aue627vXu+L014vnyeQrPKdJzBN
+        bIHzwf7inRr+XPi+s/5Xqnuw6OkPRLhoNLcAIMYUQtZaoZSDBlFPZbTdkDHe
+        yKzDwRZ1DzKqa43uwZ/HzvwBXQKy3di9url57ENS4pt39y12UhGl/KvLktW+
+        H1VnEFxBQi8FUAgQADs46wJDyBHyxjGLGGbQAMa5ByDnXmTzugQOQg2llYKR
+        QNwQCYuNVITi8JwGa8g8QMFRWevqMkWAktRRDK3jllsDmRPaSS4VjowYINZq
+        RfTCLkGlV3i9P3mutInsprzWgyj2uwK0G3VWdYBfjKs74u6uWl3CQRTJehMc
+        7amCLyksfTNsmeggihs3yXlGc/Z7L8aqn6PHv4xPOSbo5eSpvJHq8mYUqQYY
+        r+78WtA/kcOyu7psNUTrtljbfzhnTZWLT1NUvuXTqWKz8GmqMVxWEi8UhBIZ
+        hjghtNSSCO69JQpqiaXxGAjsCGd8BSiaVTOrQ9EUN/fJaMxrLmYxFCkm4ptB
+        eDICuZ3Up+7/e5dfUWbtHrtoHNUnje2Hce/ajGudB1DNsy3PU2ZtstqkoNZU
+        welgSBmci3eiyGvALeBwtF6JS6msFp4oYxm1SqDQe6RhlOUCwwCZ88WKLSVY
+        RRionFUQ+0CGWvLgVEbbIRBpEFKQgzQImw0MKZvrmSQOhWIokE5KHHgZYRse
+        iFoaPikSUJEZZrha/JyyncLuaDB8fXTNX857vZuWKxRNL/wSIUvrIdd6r+wW
+        vtbta2tb0j+WOv7iull8lBSbx04pTxb779vXJut939mmCz5XzKlq9Qrl/ugx
+        Hypmv/JMqPhns+6zgxtCYGmBxe1StEUVAxRwsbr9T8+Bat6d3e4MLy0+q1ZP
+        DbPjfFtUpah8C25TxWY7YuutsfqpkGCt0ngOL7wjKpccUciEF0ICDsLw5ZWX
+        jDGILBXGOEe1eJXbtjSey6qwdSzKWoJX+OkPPpf48s7ZehyVd9VDp7p3sHdA
+        m7XKFqUs/76oKWoTxrHpgsuPJnrBkXBUOBCdHQuiDmeQA8gyq4KTFYARUKNc
+        epBsJWmvCGkAqFTB5WPOKOgIdYFoqRVQKAEpVeGx1Fq3B3AIeiqi7QC8p8ZR
+        pF10KjZEyCNArAeeCOrg4gkGtUnhIHwu7AwKqfu/z3i4VmZDXuvhWp+b7i8a
+        QPwcJP4FQUMZfOTnk2FyL7ra3YnmtIMhSzjYblknaHXQQ23woIcPYwRL/V7H
+        QSFv852glazyLXtOFZv3eNfUgOFLFHc+wHQCGwyhDKOYA8BiJwFhwkiFnGPe
+        hbqRGLpXm8wsbcFVVq18mFX//3ZTECvZZXm1yAlgv/Uod2u3R3ZfSn/Z7F2p
+        22b+OGWy2oQ45XTBGZATzXeYFnGEU8eUotYSoBBmBlHBHLPeG0Ucw1HWOc23
+        FT+Sc+KdZ1ABrKEAMCCeiw54BcFQSIqgCUBp4bczOvIh53yxU2AIlIJp46wW
+        hplgxTAkBBEYz2VHDxlGLLt4nPK86fruedqmlAs6s5vyOqGT7h3cXfZb44Pr
+        s3K1NBhsNuojmicr5Ak6U/S+71XTBV/NmnVdux2Av+tyTl9nv/WqElsZMaav
+        7L24Lh535XXt+Kqz2VzCZrQpehOc5qmCz2W93xqowt839p0fFjYn7u8bhf3w
+        WjmLPbsAPjNcP9DAPbsbQDBf3iEJ+1tISgAQWF1qKz2q7T0OGoPT26ur7UHZ
+        7JZGzaOETIV5DklIVvnWC5gqNosX0PgWdj5vquF/DgqN21RP4MU1m9MTgBpa
+        LIzHPrAG1IIwCQSL1qlCJwllWlHNaNZRCYtuAJZVNc/WYaPd6nxrX+gpULbR
+        DU1jWlUNnOqb5t/uRq4/+TUew/8aFeQPPe8HbvgrAj/EeqMP0UP/+vqBN74J
+        Rbf4/ZZxafVGcTvsjtrtp6+HvaGKCxkzwsNX//yPf/4/AAAA//8DAL2VLrNn
+        2AAA
+    http_version: '1.1'
+  recorded_at: Sat, 14 Feb 2015 17:55:29 GMT
+recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/track_search_Wanna_Know_limit_10.yml
+++ b/spec/vcr_cassettes/track_search_Wanna_Know_limit_10.yml
@@ -151,4 +151,145 @@ http_interactions:
         BbQeG43BPS0n7US5/PYEMvNAv//42x//B3Ai25pTaAAA
     http_version: '1.1'
   recorded_at: Fri, 15 Aug 2014 20:05:28 GMT
-recorded_with: VCR 2.8.0
+- request:
+    method: get
+    uri: https://api.spotify.com/v1/search?q=Wanna+Know&type=track&limit=10&offset=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      accept:
+      - '*/*; q=0.5, application/xml'
+      accept-encoding:
+      - gzip, deflate
+      user-agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - nginx
+      date:
+      - Sat, 14 Feb 2015 17:59:04 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      keep-alive:
+      - timeout=600
+      cache-control:
+      - public, max-age=7200
+      access-control-allow-headers:
+      - Accept, Authorization, Origin, Content-Type
+      access-control-allow-origin:
+      - '*'
+      access-control-max-age:
+      - '604800'
+      access-control-allow-methods:
+      - GET, POST, OPTIONS, PUT, DELETE
+      access-control-allow-credentials:
+      - 'true'
+      content-encoding:
+      - gzip
+      x-content-type-options:
+      - nosniff
+      strict-transport-security:
+      - max-age=31536000;
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAOyd608iy7bAv5+/gvhhcm/uzJ56PybZORFxBMUnojI3N5N6
+        CiMvoVHxZP/vt7r1iDPQDdhAZuc4yVS0e7mqelXVql+tWg3/+kehsBUNlLkZ
+        bhW+FP4Vfg0XmgPn41+3mlHUH375/Fn1W38M+72o5cd/mF7n8x38PHRqYJr/
+        vB25wfjPS9Xtqv856PbuP/S8H7roT/Ch3eq0oj8h+BCN++7PpI6tj0/6W5Hr
+        JPX973ON4Zpq61Fn0obJte/x3yeteRL5+Or+nWq1lW677x01uHHRs86t7dLW
+        x1Cex2VxNyn34nJnOynLSdlIym9xWUpkSgdxuZv8vFuLy6+VpDyLy71iUiY/
+        lxPJcj0uK4l8JZGvJDVWk7+qPv2cyFQv4vJwJymT64dJ7UfVpDyOy5OkVSfJ
+        lZNE5iy5Xkv015L21xLNtaT2WqLzPGnP+WVc1mtbhf97ZR33ELlBV7W/jwbt
+        4c+WDXefu/Onbu71Xfenfk4s/pnqOrw6aDyUm7v3o5t2+xyBh+hm60XbX68q
+        XWToJFqHaWpfKWvZRNUCgh117X4ZUU/Nca3rZhTfYAR8fH0nGOWndoZWGtsN
+        TfycKPtMrHQGEuawQpRrCBgOlxSB2HlmDLYOIwqA2PpJ633LRs3n6l7ZJ61R
+        GCzXKEkZkowQBjnVWhFjrLfMWeOE4cJhaIWSytqURoXqFmgUI0u1iVnhgRaC
+        C0whNRAyb7V2EhlmKXHch4uYG5RqqEmTfhq+XdV5mvbbh6+7Ot0bjAat5Mbz
+        aPuSCHzJHrwvQ3dLDaLWMJoaQyuZRYnqz7zaFaBdr7GyA/zqrlwRt7flco5p
+        9NTiNL3T82i+4MTmAxO1TOGw171x4+Fs+yfVZ3ZAIvEl+7lfdfq7P0/351u2
+        NTTfu6OOdoPYKnByYzRQUavX/f60pCKOsHyZwWH49tst00omtlftoXt153lg
+        t+wv43qrNRyYpCf3iju7VRjcBmZoespkTI3FJkYCBZ/xDz8A519Z6dQcV1Uk
+        rve6fHdGdYvMiSeUSVP5oup5QswVG37vt9U4HpGxfDQYTcz3MlVKvUKlkABQ
+        IQagf07+vN/rj9pq0IoSM4hJp/QH7q7l7r//6lr7L66108efnqU+Gyigx8wh
+        74DXBApBjRZYCe+k54wIICniAE4qTqwwc7C8zN7XPDZj6ia3v2T1zKv1YxF2
+        G7a618GKi8Pb2ewpX0wmUfFsavonE20nubtzluUQSonM7s6izmEvaUP5KLeL
+        uEqcQ2XKUSRPcbI722mcNKZcR4rTqCftqTfWBIE4isbXtZY42eF9VYYdfj7s
+        6GJuCExRO714LSC4eggMhBemG1BWGCoFhpAj5I1jFjHMoAGMcw9ABtusAwId
+        hBpKKwUjSgiIhMUmgCnFoZ0G68BfALkAiZuEQEWAktTRQKCOW24NZE4ECORS
+        YaGUA8TawKv6zRCY6mXfgITZQ/kdCf9GSPi+SuRfJZZAS0zQ6tESrw8tiWyC
+        s8YBHj9e3nh9MT7a/7EfQCkPWqao/BUt54qtEi35W9ESCkKJDEuZEFpqSQT3
+        3hIFtcTSeAwEdoQzvga0zOqZJdFy2bDgK5+xXf9tPMfBKv3H83Z0yoscfXuT
+        L1lss7pO+iRnpyU62lakePF4W9ve62FXIl9z02eK2ul1cgHB1dMnc1RZBJin
+        EHqlnWVQOQeFMtRLBIkNG31tLd8ofQpoIGYMIYCsl5ZIY7hlGDAHqLdSCgkM
+        1Rhukj6ttkBrQ0BYnigzwUyQMAR5oFEgHGHGmADNNo2I59Pn8eBadQP8nLV6
+        UR7yzB7GGyXPfnn7pHbQ2DsCnjV8D9Gbb8PdFZDnbL0zyHOu4Iv1L1ttW9hR
+        A5sTOjMf+W3Q+b6ArHEBWRhMMaSM4hWBaf3g07aknyD9BMI/ur6wp+nQvfJt
+        5+vxdkM0+w071NVSKV/Yc7bKqbDnPLEF2XRUuE/Y9CaLTcHk+lJoqglkWjNq
+        vYbIGAKdAzYsfHHUE0HkvIGccmrT0ZS+NeqZ0TEbQdNV+ZT/ZG+yLhDlY1g6
+        +XG/oy/0pfpW2Vc1ZU9tbhBNUTtj2ZwvuHoQhZo57hFmNMxFQQOIEkgcBwpJ
+        zwmUyALsgU2P7q0FRA0mCgvtDBaGaBmfjYftqmEEg4CkxkvFqERgkyAazMOc
+        swZq4pXzWiPDpQvWEQYIbsIO23LMvHoziJ59KBZq7d59YV91UmJwi5Fo9jje
+        JInix/NjB4vR+Pzm/uiu8e344eomuspPoil6Z5wszBV8Mf9+z+Vj0OyHXZpB
+        31eK1a4Ui4dCBUKMrYo4a/sVGMMmRDNikyvCTb4Lj37w9t7NHRz6h9Lhzn3U
+        67Rz4WaKyl9xc67YIrj5Og5a+FQ4U7bVK+zaVpTGnWjSd0setwNivRQcceQp
+        sFwJwpSVATc5BwSHxUVxrThKB0+I3kieWX20ZvKczq3Jn1WTwxv8dPSRlkPz
+        73m9pqzHI3bbLdf2+pXH41L98mJ8BvVDO3/W42y108vSAoKrJz2BCQA6jpUR
+        qC3BVGiCCQ6cxSjFEEqlEfZos1mPTiGLhbCMQ6i8ldhT6ZVCyjtOGUbcesgk
+        k5skPYFgwDyiOFSOcacIIEZhLpnQEoYr3AX8tOjtIcd6v1DpFmqd3k0KciyY
+        /pg5ijcacdwdk5MSOWwMDwytINtr1+/1Ks66Z+udsXWaKzg563aD3rDTCn2V
+        L+KY+ci5Mh//jt55YbqCAohXi2jeg+bDwxrEDCAG1kZX6Lz+YzT6NhbblS41
+        LmrJiupUctFVispf6Wqu2NJ0ddkcvxBWcdBT1qhhVKi27lzhpBlGqXXtfrOl
+        ClBykUZfcBJ8W46+EEFIYmktJ0RCBrwjiMqwu+dxzmNYfhwkVr/y9dP0NQkE
+        L0dfWX24JH2FnuwHS8VD+v1g+rc7V1glJWJvLR7tFPeu61e7nVqt2brYOxzl
+        T4ucrXZG8GK+4OopkROFqKHhP9PGQM0w8VAT5gwzFAqugedOwPQw1zookQmr
+        PRTe4ACu3HLvEXCAaQU4klozbpxk1LlNUqJDlhlgBPGEII+ckMAzBrhnTgqB
+        ECeGUYTpmylxzw06qlso90ZDVzgMftoNhh8LF732HwWRBxuzh/UmsZGVSvfw
+        6G5wV2xUB3ftprIU84f82Jiid3qGzRd86Y3zpiucO2WaoRfykWP2U/80Pldo
+        a3hXueo0tnv6YPum3i7iQblRbq4gKSBF77St5wu+2Pqo59qBR3qu23rIZ+vs
+        p16XrXFVXO6UcK1Yq5wWf9zu3FzVyqd7Kwh7z9Y7Y+WYK/hi653ewI0L2107
+        cPc549+ZT/2eg/HbsdLiORiCUr6qHIzS7qXgkABM5PqSg/lBw12Usa1WxGAE
+        an33eNMmV/ki4rNVTkXE54ktsmd7tWNr9EaFoouCVcLGrdrThQ+F83ibVjhz
+        nVfecUWZGQJIrl3obKHjV44xJ5Ihp6WAjHEgWSBCSYXKShqeVL1kgDyjyza3
+        RZvjalKczGrdywzHksOlzHAmi7iRi41ts1Dz/hA98jE9vjy72fkmzYk6rt7m
+        3malqJ1eLBcQXEPaBcBCBvJzCofNlAKUEQUwg9wDzLXBhFMsJdns22ceMMYk
+        ooxSwSBEjgLHlPMWKAckslyFXRaVeJPbLBq2e8FAWkOknOFKWwMtlYZJboVH
+        BmCNIUHm7dusgVORG0aFcivKlXaRPY7f0y7+FmkX7/5/If+/eDKFZGLihVaV
+        TAEoXxs6MhMN4AE/eDzYHTxov7c97lbFdi50TFH5KzrOFVs23J9Gh+ytEXxt
+        g/tVmqPAiQERtSVCasGEBBYIRrT32gLrMyL4k7fZlqPDrF55T5+YmsmvtoJh
+        E7imJIrHb4djedrUj3fbP3o3o0Hxbvc6f7psitoZSRTzBdfAbQwqwgTUiDrE
+        FZcQ8fjNfIydERiGyaGokDw9N2Ad3EYws5By5wCVEnipHbbUEi/jV7ZU+B2p
+        QHI87WWytXBb2N97agRFiKkYblmwjIZEgDi5jjOslHAWyrR3yeZzWzFmtp4v
+        lGN314zfXY9UV+UBuOwBvdF8im6dNIuAgOvzTrlDaKNxeHdrVpBPMVvvjHyK
+        uYIv/bCI/RdOqsh87nWFa9GO7JLo9Pqo2iyfNGs7HTs87eb5DLxna6fonbED
+        nSs4eTVH3bVsYXtgmqO2i3KaO/vB/0NyWH5dIhfPZGECyZW9mVa7LMEAVQzz
+        9b2Whi7uL8fHJ+3yyLmzztG30XXn6HyYL5NltsqpTJZ5YktnsjR6ozS8JeKN
+        eIsNYpIhzRk1xAIjAu0ay+OklLCkCiwoFx5Smo63k5qXzE/J6Jn3j0x4uyf4
+        Ld48WCV0s/M67Z6hS3N/PL4+uN4umx/8keeG7hS1M07M5wsuAN1YLpeT4gLc
+        WsoNwEgJY7WnTmCnkOcca+mtMxpAlhaXXAy6kVyuUU4Ray0KnGuYNIhLpgWF
+        1DGCFBEeKIi5ZiotMLkW6EYKI68AsMpgoITAlkEshKDxaY6yUEEfjJcRVZ4H
+        3YfOjh7j9EAiPiEAUOG/knwU+N95uDt7TG80cGoOd1ul4YO86O/dfeWwWd8b
+        3tdWEDidrXdG4HSu4EtX7FrbcoWnDskZQc186veD+99oKVkcTiUnaFUvsdV2
+        T04PAYMwfuV2XXAKq49fG5DXOzcXtWHJ/Rgf7OwfjnPBaYrKX+F0rthCcOqT
+        o/ozp9rt8QIxWDzpnOUg1TsKoWJchhVQKi0k9AaywKwWSIkdshwgjx1Ih1Q4
+        qXo5Ss3qot+GUv8uTmWzjmRNH90Fj+/F6deLKryoirPKVbV3VZbH+T+6a7ba
+        6eVyAcFFaJQvBVkYOaAMsMAKZ5jACmMEsacmPodGlEnIrFM5Pzh2WRoVnivj
+        HPaceAdM3EKlmJdIxwf3TEATf8at2Oi3B2hMvEbYYu8cwwpq6qX1ijorHdKO
+        M4yl1u7tR/dFd1342hsECBqYcR4CzR7HG02JdncHJbp/uX98hG9PivtRfbcT
+        NVaQEj1b74wN3lzBSebEp3q3FeVjz+znXVuC7nuCxFrx/n0Nzl6DF0+fYBSk
+        YPxPGLpYiLlyBgGGiCC5vhDz/nH9evvIj69BVZ5csf7h1/vmjE9BXCbEPFvl
+        VIh5ntjiibd7Liqc9+bGmelbs2w9tEhQEPqBMOYCEFApkRMeOe0J9QwQKagA
+        Oh3h30rwWd3z4gm2kq/3Ssbl8xNudcPwmNddc741DGZ+bdiTUFzFv6tMjNUb
+        JWOxO2q3ny9HvUi1nzZQhIdLf/3jr/8HAAD//wMAgz2xxulsAAA=
+    http_version: '1.1'
+  recorded_at: Sat, 14 Feb 2015 17:59:04 GMT
+recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/track_search_Wanna_Know_limit_10_offset_10.yml
+++ b/spec/vcr_cassettes/track_search_Wanna_Know_limit_10_offset_10.yml
@@ -151,4 +151,143 @@ http_interactions:
         0TfUWivY7nebHfVG0has9xhnMAp//O2P/wMxOsNQ9GgAAA==
     http_version: '1.1'
   recorded_at: Fri, 15 Aug 2014 20:05:28 GMT
-recorded_with: VCR 2.8.0
+- request:
+    method: get
+    uri: https://api.spotify.com/v1/search?q=Wanna+Know&type=track&limit=10&offset=10
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      accept:
+      - '*/*; q=0.5, application/xml'
+      accept-encoding:
+      - gzip, deflate
+      user-agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - nginx
+      date:
+      - Sat, 14 Feb 2015 18:01:41 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      keep-alive:
+      - timeout=600
+      cache-control:
+      - public, max-age=7200
+      access-control-allow-headers:
+      - Accept, Authorization, Origin, Content-Type
+      access-control-allow-origin:
+      - '*'
+      access-control-max-age:
+      - '604800'
+      access-control-allow-methods:
+      - GET, POST, OPTIONS, PUT, DELETE
+      access-control-allow-credentials:
+      - 'true'
+      content-encoding:
+      - gzip
+      x-content-type-options:
+      - nosniff
+      strict-transport-security:
+      - max-age=31536000;
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAOyd6VLjSLaA/89TOPjR0xPT0+S+VERHh212MFAFZvGdGxW5
+        YhXekBdsJvo97vvcF5u0YLABywuy3dU9/MmwpeOTR7mc/M5RSv7XX3K5jU6s
+        zG17I/cp96/wNRyoxs4Pv25UO51W+9PmpmpFP7dbzU7kBz+bZn2zBzfbTsWm
+        +utd18WDXy5Vo6H+ftho3v/Q9L7tOr9A8EMtqkfJh86g5X5JKtn46bGCqOPq
+        SYX/81RlOKZqulsfGTE69nX4+8ScR5Gfxs73VFRTuua+1lV86zpPOjfyWxs/
+        hfJLUp4nZXlYFraTcjcpT5IykSnuJeVRUibHi4/Hr5OyMiy3kt9uHSZlIrNd
+        TMrk+PbZsNzZT8rkt7uFpHz8nNiwl/x27zgpE3v2k9/uJ7/dT2SOEg1Hj58T
+        maOLYVlK6iolx48TmePE2uPEkuPEwtN8UiY6T5MrOk1kTpNfnSbX8iWRP0tk
+        zpJ2OEu0nSW2nSV1nV8Oy/L1Ru5/x9ra9Tsubqja125ca7/sp3D2aXS8GDXN
+        lmu8GDZJ/23i4rfu+aBzVHnAu/KhcdVB8cFNeeNZ229jlc4zEhOt7TS1Y8oi
+        m6iaQ7Cubtyr8flojotuqp3hCUbAT+NnQqO8sDNYaWwjmLiZKNt00BNuuEAc
+        euONJgQqxaWkmmKIpZVMUU2U2Xih9T6ynepTdWPtk2YUBosZRSA1mlOCidCO
+        O6o0ttpoJaXlwgqKPYXAaphiVKhuDqMYWcgmGGxAgnMqhUZSQ68BsUhaxxk1
+        IljEGEdO0tSGGpn0Yvg2VP3RiZzt5beury7G+zvdwXTjKDnxNOQ+JQKfpo/g
+        5/G7oeJO1O68GUhLmUqJ6k101Wj0Pz/0dyq74m779Ju6bd6eljLMpUeL0/S+
+        nUyzBZ8b/kRHLnceR8ZNbvuk6qmNn0h8mn7NY73+sTysa3nYsFHbfG1069rF
+        wzZGoxPdWHWiZuPr43qPCKEYP591/VYtMlHiJzpx142deJohkX01QTaidmyS
+        YVE+K5c4oAAxKt/OvSlzbL4ZlgDLJq3f1BuNXuki7sUCIFU5vWrZz2+rm2dy
+        PXJWmspnVU8za6ZY+2urpgbD4f2m+Z7nXAJmuSGYjX7Yara6NRVHnaQBCBud
+        iF0vcvdfX7vo1rOLrrfwP56kNiGGXGIHrJcIgLCEUcW51ZIizJB0lmgOkRNg
+        VHFy/WOjBILRqf94gXFMnOACktOfpnXK2EI0D1K2o8ZNza2EKfN/PNdRukrK
+        67W4kS9rYE1yCb99699v2Ru6HcNLeLBf1gxnZs0UtW+XxzkEl8+akhJCNETa
+        K2MUZZ4TZEmgOi4EZj4c1VoBQ9bKmppLj5VXGhFDmAiOwWkFAbKYhe/MW4El
+        ET7NqJWwJksQ02EtLGHEe8Qxcdwwg4iT3DsHDQ+8mQ7ls1jzutnNTXDB70DO
+        6QN5ncgJ1UmHHfWuTi7YvrA9mKdbUaSyI2eK3rdzarbgc/tvnRznCl9Oho43
+        C3FOv+SVEOfH4vG+xeM1icJUEg3IwkYAMk6iXtXai6HobiH/5QhiAAGHK0NR
+        XHmQt8eX983+ZekIlfFt3j30fSYUTVH5GkVnis2Doim+8BWO0lGHLYajDEtk
+        EDUKuKEv5wAhihSREhIPvJUCYceBRVNw9J00Oq1fFqTR1SU4P/zJ7w+j+Fuv
+        cHqQV4VBfO6Ob7dvevcV182e+JysdkLic7bg8mEUKU2dZNwLySVA3GvHleMU
+        CKUUgsxL4bS2cq0wCrTgFnptFNZEe6Gg9Vh7z6QhEgisDcAMa7VOGEWhMRDT
+        0hqCjFQitJGlWCEegBRAgYiHHAfz3g2jx81cadCpNmvNm8i1c51mbqdZqzXv
+        cz9uuVq37/6WKSU6dWyvk0+Btj5Sg8/5Q3d/t91TZRZfFXvZ+TRF79tpNlvw
+        uUtK//9/2ch0+sV+kOl3tJLMT6YUQzHKyi2LTMXqkqSk0JC3152CZMeqdUNv
+        B5/9wNQzkWmKytdkOlNsHjI9dj0Xz8Omo3BhMTZVShjrNHIUGMONglppT2hY
+        cxy0YaXxVFrFHU9n01HKfDE2ndYz3w2bfj++5Pv3IsvkUbCrd2n9+mwnkuCk
+        fT0ok+rOTjEzj6aonbBQzhZcPo8yqhgnmhDjNNcAYy5h4FBimSeaIkyQskgK
+        v1YepcQZICF00EjIoNHOYQ6gU0YawBWj3DsGvVgnj2IybBlHpOHAcUy5kxwq
+        iTViEFJKAYDhoE9vqFk8mm8MdNMOnhxvoTvI5XN7LoDNr1lAdPqgXuu9+dh1
+        znlp535v6+Lc7R5u2YHe7i/h3vxkvRPuzc8UfO6Lw59zpchUXe3lvbB33Jyf
+        etF/8pvz3//yMT+EQoqXBqHls/x5cLGAULnC9Ohh/eAwqhjdgDtH9u5LO7Z7
+        xd1s6dHJKt+kR2eJzQOheyEQ32rmhlnSIYP+mgah5L0JUi6EIpQJCDVXwlLv
+        FdLGKykQIF4T64XREky5X0/fmyCd0jMft+v/iHHt2Uq5FJd6+fPrQfHqpt47
+        uVOX33qfZfM8e550stoJedLZgsvnUg6UY4xrImAgLicINpAr7g0AjiDJhWaA
+        OOXWyqUGa005glYBqrmkwkGBtTLYUyOsBJQwLgiw6+RSBQ01LPgwwKUIZCo1
+        4EhgTr2RyAKlJJJa8PSGmsWlheg2akS5LfXgctunmZKiUwfyR1L0Iyn6sXgk
+        /bBAahTBydtHv9PUKOa7O6javCwWd8v7qKHuUeWicp+NSierfEOls8SWmRol
+        4p1UKhlHQAuElJEyFFSGr4gzzH2AUuO9s8xCI9KpdLTXeEEqndIzH1T653As
+        y6RSXr26kIN298I3Lu8oisVB8ywYlJVKU9S+XUHnEFzBY0uYCoAtNQCGucmN
+        IQxyZl0gL26ItA5px4hDa6VSgR1VlhnMGUVOeYKg0Mhb41yAQcg0GiZxxVqz
+        pZRBTAjwIbRGTAESgNl6raESAiODMPbWeozTdhTMptKRD05yBNnAdPpYXiuY
+        HuIBbxx3728r50f73c8PN1en8fUSwHSy3glgOlNwtJs0ip3pZGTTqdf7Yjgu
+        MxVNTsRO54Hl73SziMvqXkf3JF5CKnqy3gmp6JmCY4mwWm2Q24q79XqzYbO1
+        9vTr/ogEvrsFe/5IgAEElrV9t5hnWwgCADAiq4sEzvqVTvE0Lw8qTdfYPbg5
+        EufNZrZIYLLKN5HALLHFniRL1p8fvVOdn3MvJ+vfUsODUep4sfCACDdczS0A
+        iDGFkLVWKOWgQdRTqRTzxngjYXp48O5dvVO6a43hwX+Pn/kDhgRkt3xQub19
+        iCEp8O27+4h92RKF7E+XTVb7dlWdQ3AFG3opgEKAANghWBcYQo6QN45ZxDCD
+        BjDOPQBmvSGBg1BDaaVgJBA3RMJiIxWhONhpsIbMAxQClbU+XaYIUJI6iqF1
+        3HJrIHNCO8mlwkMnBoi1WhH97pBgq5nbH8vNZNo2MX0orzMi4EcNAWrlM7bn
+        AL/q7e2Lu7u9veysmqJ3QqA9U3C0hSU2ncjkSs3GrRu0s7Hq9Ot+H6t+rB6/
+        G59yTNCzv8icqS5uDzPVAGO0Mj4F8RfZKbrKdVQWUStfOupfsqrKxKcpKl/z
+        6Uyxefg01RkuaxMvFIQSGZY4IbTUkgjuvSUKaoml8RgI7AhnfAUoOq1nVoei
+        KWHuk9NY1F3M4yhSXMSjQ3hyApmD1Kfp/58pv6KdtYfsqnx6Nijv9nvNG9Mr
+        1ftgL8treZ521k5WOympNVNwNhhSBhfinWHmNeAWcHj4vBKXUlktPFHGMmqV
+        QGH2SMMoywSGATIXyxVbSrAaYqByVkHsAxlqyUNQOXwdApEGIQU5SIOw+cCQ
+        soVskjg0iqFAOilx4GWEbTCIWho+KRJQkRlmuEp77dZsMNzPHXTbnTFvmPvx
+        stm8jVwub5rhzBBZon6m572mj/B18iIr7Uj/UKj7q5tq/kFSbB7qhSy72J94
+        MUXv28k2W/C5Y85V1MwV4+5DNlScfslzoeJ/m3efH9wQAktLLO4Whq+oYoAC
+        LlYGbugSqOrdRWu/c23xxd7euWG2l+0VVSkqX4PbTLF5wO2ts/pHboK3SuM5
+        /F6e81xyRCETXggJOAjLl1deMsYgslQY4xzVYmxv29J4blqHreOhrCVEhR/x
+        4HOLLw0a2UO3eKD69b3D48NjWi1t7VDKsr8XNUXthHVstuDys4lecCQcFQ4Q
+        LyUYTjiDHECWWRWCrACMgBrl0pNkK9n2ipAGgEoVQj7mjIKOUBeIlloBhRKQ
+        UhXMUmt9PYBD0FMxfB2A99Q4irRTmiOIkEeAWA88EdTB928wKA1yx+Fzbr+d
+        O2imPAU0HxtOH8jrZEP8cH7iYKEzOL+9P+5dV076V7edq+xsmKL37ZyaLfjc
+        /qmNPi8VTr/YRROIH4vE75A0lCFG5ktiz/LZwf7wnnZwZHxl7AnrqF9q93Wn
+        30OwEDfrDgrZysSeKSpfs+dMsfnYc46n/kdZ3MUA0wlsMIQyrGIOAIudBIQJ
+        IxVyjnkX+kZi6MZeMrO0B66m9cp389T/n+4WxEresrxa5AQwjh7kQal1ao+k
+        9NfVZkW1qtnzlJPVTshTzhacAzkRX4ikiCOcOqYUtZYAhTAziArmmPXeKOIY
+        Hu46p9lexY/kgnjnGVQAaygADIjnDJMGBEchKYImAKWFngEiM+5pXSx3CgyB
+        UjBtnNXCMBO8GIaEIAKTe9lDI8OKZd+fp7ysutg937YpZILO6UN5ndBJD4/v
+        ruOod3xzUdwrtNvb5bMuzbIr5Ak6U/S+nVWzBcfumjVcrRaAv+Ey3r6eftWr
+        2tjKiDGxsvfiJv+5IW9Knyv17eoSXkabondC0DxT8Lmtj6K2yv1z48j5Tm57
+        4P65kTsKl5Wx2ac3wMcO1+9o4Z4/DCCYL+9PEo52kJQAILC6ra30tHT40C63
+        z1uVym67aA4K3erphJ0Ki/xJwmSVr6OAmWLzRAHlx7TzZVV1/trOlVupkcAo
+        NFswEoAaWiyMxz6wBtSCMAkEGz6nCp0klGlFNaPT/irhvS8Am9Y1z95hI/mr
+        rqSep0TZRiMMjVldNeMvwNDUvwB7FHpRZ9JczW47Y71Tq+00OyrpMswID4d+
+        +8tv/wYAAP//AwCmGSp1BG0AAA==
+    http_version: '1.1'
+  recorded_at: Sat, 14 Feb 2015 18:01:41 GMT
+recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/track_search_Wanna_Know_market_ES.yml
+++ b/spec/vcr_cassettes/track_search_Wanna_Know_market_ES.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       accept:
-      - "*/*; q=0.5, application/xml"
+      - '*/*; q=0.5, application/xml'
       accept-encoding:
       - gzip, deflate
       user-agent:
@@ -37,7 +37,7 @@ http_interactions:
       access-control-allow-headers:
       - Accept, Authorization, Origin, Content-Type
       access-control-allow-origin:
-      - "*"
+      - '*'
       access-control-max-age:
       - '604800'
       access-control-allow-methods:
@@ -227,4 +227,202 @@ http_interactions:
         f37eB5s41AAA
     http_version: '1.1'
   recorded_at: Fri, 21 Nov 2014 22:13:11 GMT
+- request:
+    method: get
+    uri: https://api.spotify.com/v1/search?q=Wanna+Know&type=track&limit=20&offset=0&market=ES
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      accept:
+      - '*/*; q=0.5, application/xml'
+      accept-encoding:
+      - gzip, deflate
+      user-agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - nginx
+      date:
+      - Sat, 14 Feb 2015 18:02:17 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      keep-alive:
+      - timeout=600
+      cache-control:
+      - public, max-age=7200
+      access-control-allow-headers:
+      - Accept, Authorization, Origin, Content-Type
+      access-control-allow-origin:
+      - '*'
+      access-control-max-age:
+      - '604800'
+      access-control-allow-methods:
+      - GET, POST, OPTIONS, PUT, DELETE
+      access-control-allow-credentials:
+      - 'true'
+      content-encoding:
+      - gzip
+      x-content-type-options:
+      - nosniff
+      strict-transport-security:
+      - max-age=31536000;
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAOyd6W4bSZKA/89TEP7h3cV0j/M+GjAGokjdl0VR12LRyFOk
+        eEnFQ6IG8x77Pvtim1V2i7LIKh5FcuweGnBBIkNRWXlEfhkZGfWPvxQKH3qR
+        Mo3uh8JvhX+EX8MHtcj5+NcPtV7vofvbp0/qof637kOnV/fDv5lO69MAfuo6
+        FZna3x/7Lhp+vlLttvrrYbvz9LHjfdf1PoOPzXqr3vuMwMfe8MF9Tu7xsaWi
+        RviyXPnwy9c71Xuuldz5v7/dO3ymmrrfGpVm9NnvsaakXF9Ffnnz/UDVm0o3
+        3e9fb/FN54et0odfwvUivhbLyXU3vm5vJde95HqTXG/jaymRKR3G13Lyc1zW
+        woed/eR6Hl93i8k1+Xkvkdyrxtf9RH4/kd9P7niU/NXR158TmaPL+Hq8nVyT
+        z4+Tu58cJdfT+HqWlOos+eQskTlPPq8k+itJ+SuJ5kpy90qi8yIpz8VVfK1W
+        PhT+503tuOeei9qq+Xs/ana/r9nw7beG/a7BOw+u/V2LJzX+ieoqvD68ed6r
+        lZ/6jWbzAoHnXuPDq7Z/vrnpLJ0o0dpNU/tGWd0mqmYQbKk7965HfS2Oq9/V
+        evEXjIBf3n4TKuW7coZSGtsORfyUKPtErHQGEuawQpRrCBgOHykCsfPMGGwd
+        RhQA8eE7rU9126t9u92b+kkrFAbzFUpShiQjhEFOtVbEGOstc9Y4YbhwGFqh
+        pLI2pVDhdjMUipG5ysSs8EALwQWmkBoImbdaO4kMs5Q47sOHmBuUWlGjIn3X
+        fduq9XXYbx2/bep0a9CP6skX33rbb4nAb9md97XrflBRr97tjfWhpYyiRPUn
+        ftQWoFmtsD0H+PVgb188Pu7t5RhGX0ucpnd8HE0XHNV5ZHp1UzjutBtu2J1c
+        /8ntMxsgkfgt+7nfNPrGnqfb8w+23jW/t/st7aK4VuDoi36kevVO+/evUyri
+        CMvXERy670OzburJwPaq2XVvvvnWsev2Xb/+UO9GJmnJ3eJ2+QgGs4EZGh8y
+        GUNjtoGR4MEnfO8jcLHDSl/M6ZHqibvdNi9PuN0sY+Ir1KSpfFX1bUBMFev+
+        /tBUw7hHxvK9qD+qvtehUuoU9gsJChViFPr76M8fOg/9porqvaQaxKhRHiI3
+        qLun39+b1odX09p6wL9+k/pkoIAeM4e8A14TKAQ1WmAlvJOeMyKApIgDOLpx
+        UgsTO8vr6E1ERn/xfugmX/+W1TJv5o9Z2K1bb9+FWpwd3s4nD/liMoiK52PD
+        Pxlo28m32+dZBqGUyJS3ZzUOu0kZ9k5ym4jrxDjsjxmK5CnOypONxtnNmOlI
+        MRrVpDzVmxVBIO71hneVujjb5g9qD7b4Rbeli7khMEXt+OQ1g+DyITAQXhhu
+        QFlhqBQYQo6QN45ZxDCDBjDOPQAZbLMKCHQQaiitFIwoISASFpsAphSHchqs
+        A38B5AIkrhMCFQFKUkcDgTpuuTWQOREgkEuFhVIOEGsDr+qFITDVyi6AhNld
+        eYOEPxESbmaJ/LPEHGiJCVo+WuLVoSWRNXB+c4iHL1cNry+HJwf3BwGU8qBl
+        isr3aDlVbJloyRdFSygIJTJMZUJoqSUR3HtLFNQSS+MxENgRzvgK0DKrZeZE
+        y3ndgm9sxlb1h7Ech8u0H9+Wo2NW5OR2IVsy22J1lfRJzr+UaH9LkeLly2Nl
+        a7eDXYns5KbPFLXj8+QMgsunT+aosggwTyH0SjvLoHIOCmWolwgSGxb62lq+
+        VvoU0EDMGEIAWS8tkcZwyzBgDlBvpRQSGKoxXCd9Wm2B1oaAMD1RZkI1QcIQ
+        5IFGgXCEGWMCNNs0Ip5On6fRnWoH+Dmvd3p5yDO7G6+VPB/2ts4qhze7J8Cz
+        G99BtHHbLS+BPCfrnUCeUwVfa/+q3rSFbRXZnNCZ+ciLQedmAlnhBDIzmGJI
+        GcVLAtPq4a9bkv4K6a8g/KOrc3uaFt3de2ztnG7diNrDje3qo1Ipn9tzssox
+        t+c0sRnZtF94Sti0kcWmYPT5XGiqCWRaM2q9hsgYAp0DNkx8sdcTQeS8gZxy
+        atPRlC7q9cxomBWj6fgOR/69jRy24LsFaNpOxh+jekV7zyfssb1X2X3Yfzkt
+        Va8uh+dQPzfz7z1PVjth73m64PLBT2ACgI6JhUBtCaZCE0ywwoJRiiGUSiPs
+        0Xr3np1CFgthw3IQqkB62FPplULKO04ZRtx6yCST6wQ/gaA1kCgewJhxpwIB
+        GoW5ZGE5C8Mn3EnFLFoc/KoPhf12odLqNFwe7svuxWvlvvKQnJXI8U330NB9
+        ZDvN6pNehsdxst4J3DdVcORxdFGn26qHtsrHfZmPnGv/+We0zjNTFRRAQLQ0
+        d9/xcSUsHAFiYGVIhS6q9/3+7VBs7bepcb263Fet/VxIlaLyPVJNFZsFqd76
+        +gpXtWHh18K5svVOoRh1lDWq2ysc1QeucFYLvdS65kOtrgpQcpHGXnCEQPPB
+        FyIISSyt5YRIyIB3BFGppeTxznOYfhwkVr+x9eN+wRGOz0dfWW24FsfgslZ0
+        /85ruVW5AfkQls7un7b1pb5St/sHqqLsF5ubBlPUTpi8pgsunwahZo57hBkN
+        KyFBnWUEEseBQtJzAiWyAHtg0/dWV+IGNJgEHtXOYGFIsAyUIeyIYQQDw63x
+        AbyoRGCdNBiqhzkXgFATr5zXGhkuXagdYYAIlksSyzHzamEaPP9YLFSawTgf
+        qFbKDuhsPJjdj9fJg/jl4tTBYm940Xg6Gdzcnj5fN3rX+XkwRe+EuI6pgq/V
+        f9BJgfBZSTD7Yef2AG5miuXOFLNvRAuEGFuWv69ysA9jVx9EE3aGl0SmvAxP
+        7nlztzGAXf9cOt5+6nVaExaAc5Bpisr3ZDpVbG4y/YNKy7beSyNPNGq7OYMd
+        AbFeCo448hRYrgRhykoDOeeA4DC5KK4VRxnkOVqyzEeeWW00J3mGlnoI9iPu
+        svPy5xR7kmJJlrt/MMGG5LAeE+zGLBbj8o2VWO3mMqo9HaMXPqSnV+eN7Vtp
+        ztTp0WNuqkxROz4FziC4AqoMWCSVpS5QHFQKUEYUwAxyDzDXge44xVKS9YY2
+        esAYk4gySgWDEDkKHAsoZ4FyIIAuVzJ8JfE6qZJyy0MF6UCXyhmudABMS6Vh
+        klvhkQFYY0iQWZgqdyOnei4s7vfqvVxUmd2PN1T5U1Dlxv7PZP9nZ0XJxMgK
+        LYsVAeUrY0VmehE85Icvh+XoWfvdrWH7SGzlYsUUle9ZcarYvKyYhodsUcek
+        tsH8Ks2RABILrS0RUgsmJLBAMKK91xYEgEzHw1Go5Hx0mNUq66PDTdTJTxW2
+        iL21uL9d3L2rXpdblUqtfrl73M9/aGay2gnT4HTB5ZMlJwpRQ8N/po2BmmHi
+        oSbMGWYoFFwDz11gzrWSJRNWeyi8wcFmBKLzHgEHmFaAI6k148YFtHRunWTp
+        kGUGGEE8IcgjF6yYZwxwz5wUAiFODKMI08XJ0kUt1S7sdfpdVzhW3dCru78U
+        LjvNvxVEHtDM7tbrBE1WKj3Bk0E0KN4cRYNmLSxoMH/OD5opesdH2HTB19a4
+        qLnChVOmFlohH3FmP/V3/XOJdQ0H+9etm62OPtxqVJtFHO3d7NWWEDKaone8
+        rqcLvtb1Scc1C2e1jmvXn/PVdfZTr6qu8ZG42i7hSrGy/6V4/7jduK7sfdld
+        wgJqst4JM8dUwde63u5EbljYatvIPeVcSWU+9SZC94djpdkjdAWlfFkRuqXy
+        leCQAEzk6o6O8cMbd7mH7dG+iPqg8uBeGk1ync9jP1nlmMd+mtgsq7A3/vqb
+        Tr9QdL1QK4VfC0cdXfhYuIjDRwrnrvXGOi4pbjcszLh2obGFjhPSYE4kQ05L
+        ARnjQLJAhJIKlXWkbHTrOR34GU3275auYC225idckZHd6sFto/ESQVLk5cen
+        OjsvifxpDFLUjs+rMwhu0hhs0hjMdJgssytv0hhs0hhsZo/CPDsFP116AxCd
+        y962u72pV0X9Yev46PmK1VQuRk1R+Z5Rp4otM70BXZRF/3XpDbJaZoOiP68x
+        2aDo1+JsUHSDohsU3aDoZvZYCYpCwoTgS0dRyVaGohQ91buqC0r3xcblzlmD
+        dS+vGzgXiqaofI+iU8VmQVEEIE7Fz1FA8ZyuUCWsMRIgRaRHgnrJEEEMKGet
+        oMw47ogCJiNYZdFQ5qzW2GTXWpUV+QkP1OH7QfHsYEsVh9GFO2mU7wZPt24J
+        ASqT1U7YZpwuuAIGVZo6ybgXgaYA4l47rhynIHCVQoH2pHBa27RMBqthUKAF
+        t9Bro7Am2gsFrcfaeyYNkWGlqg3ADOu0qJmVMCgKlYGYltYQFIBYhDqyFCvE
+        uWEB4xHxkONQvIUZ9KRTOB72ap1m567uuoVep7DTacYH7P6z5Jr9Z/dfuaJU
+        Mvv2OqEUaOvravhl69A9PZYHqsqi6+1BfihN0Ts+zKYLvjbJ8f/9bz4SzX7Y
+        zSb+DzSTzO4aDctQsawDd7vFrfOYRyEQcnWZX4tt2bjpFSU7UQ93tDH84oem
+        lS/z62SV73l0qtgsPHriBi6aIZB6YdeoUsJYp+MTNsZwo6BW2hMa5hwHbZhp
+        PJVWccfT2XTRBA9ZLbNJrzU2pt+M5jCOV5Rk6+X2eCi/1PTLYOu+0+hHxUH5
+        Ln9ahRS149PTDIIrOADHoArLbKgRdYgrLiHisbcPY2cEhkZpRQMgpueOWgUF
+        EswspNw5QKUEXmqHLbXEyzixqgq/I0WB42kpX1dCgQATT42gCDEVnxJkoWY0
+        JALEh7A5w8GUOAtlWsbX6RRYjA+/dXxhLzZ3tdgf1lNtlQf9sjv0Wv2R7Sqp
+        FQEBdxetvRahNzfHg0ezBH/kZL0T/JFTBV/bYZb6n9kfmfncqwqbRduyTXpf
+        7k6Oantntcp2y3a/tPO8qe5bbafoHa/t6YIj/7sa1G1hKzK1ftP1clZ39oP/
+        m+Q4ez9Fzu5uZQLJpeWPrVyVIJBhsc5XlzwWXT5dDU/Pmnt9585bJ7f9u9bJ
+        RTdfprPJKt/j7VSxufNJ3HT6aXhLxIJ4iw1ikiHNGTXEAiO0NcbyOGlZmFIF
+        FpQLDylNx9vRnefMX5bRMivD24vFx+vcI/Xyzej812aG7Z9GL7fwGVcpGipe
+        5VsnN34JmWEnqp0ArdMFlw+tVhpnnCeQSmMBdFpgozENvOqDwSFJKn6BdTqL
+        rQJaOSbKee48kBQqxTTQYWVJWPhdGkmQJBwDmkrSK4FWKSjElmsrIDMoGAHF
+        rWIUs/DPBlrFhEtCxeKZYS/qLfcf3cJWs1nY7bRzZofN6slrdVRe8v5ltH8T
+        kZ2nnUH1RFZI4yZagqNyst4JjsqpgiMXSd00wjQSHr0Wn2/M6bTMfPCZ+Oln
+        scGzO/1IWIIuL8tWSZQQABRMev/Sss7sRN3WfuP4pFP60h9uy667jm6P871J
+        NEXleyqaKjYLFVXUsDBL9gQ8apT5qIh4or1EHgvLFBDeSoiRwRBhAyVAQJE4
+        x5Zly4+HzGqZNcZDbvYRfvgdaXZye3ZWrz7Wzg6u0QVoq2Hl0pVyY12K2vEZ
+        aAbBFbxs3lkNCUAeWuWJRYFbJHIifpMShwBKBQhXmq83ZQK1VFlnFcaGcIQp
+        ZdwKFtjTESyxkdowKLRZqy/SY0KR51BqLT2ykEkkDKMQcK3jF4QI6bzSdnFf
+        5OuJycQM56G67I681iQJBzX1cj84uWJYDenN804f2HuUn+pS9E4YU1MFX+sf
+        R7ZQtnc5cS77iTd70D/Q3DG7k04Sxpe4B31TDsQDmRCrO55TfeTXRA6BaOEd
+        MTyGlp0fTYiKnud4zmSV73F0qtgsOJpiCt+76BbdgZaecEwstc5RjzUwjghL
+        uYiDI7lNXvCkhFJm+TCa1S4bGP0ZDcqKs3gdD7Yubobb13etwemjuroffJGd
+        i/xBkpPVjk+fMwiuIIsXUI4xromA0nAnSFgjcsW9AcARJLnQDBCn0hJmrQZJ
+        DdaachQoGQQyllQ4KLBWBscb1FYCGqYIQYBdJ5IqaOJMZ1wBLgVwXGrAkcCc
+        ehO/mkEpiaQWPL2ipiFpsd6ot+uFknpxhfJZrojIzI68iYjcRERuJo+kHeaI
+        i0RwWRvHa4mLxHx3B9U6V9vbu9V91FZP6Pby9infW0cnq3zPpFPFlhkXufDG
+        sWQcAS0QUkbKcInfYaMRZ5h74rXx3llmoRHpVLromZ2sllnHmZ3v7MfsluOt
+        zUizFjPYia8W4jt78NYSrNIGrAga94VpoUfZFbZ/x4rP1GzLqzyBX9+gcbLa
+        CdA4XXAFMZXIBuKhLj7lDSUijkEtracgYCOmgjIumbI6jc9WFFMJGbFeQeIw
+        gdZaFtabAnJqMSOhfNQRCEPp1ro9zaWSVAltVYyzgijhQ9VZS3UoU1gFK4J4
+        KCRbGBpLzsdvqQoz1B8JX38r7NZDny4c9Lu9/N7N7O691gjLfvQILv3jc/mm
+        XK7fVhtOX1+QJURYTtY7PtKmC762CoQoH0pmP+zc7xrYmPw53I+CiMnvEfgO
+        VWbcDD9AyVY4Wh3pwWqrKOuN1nm9eTvcfjlvgMs9MuH42xykl6LyPelNFZuF
+        9KqFrWbklB1mc96i75kiIo5il9pTqKHXQDFoA+p56bAkXiLssLZIZXDeoi8S
+        yGqXjffxZ1xArixB0BW8v39+Ktk7Wo7gFTzYr2qGcyNkitrxiW0GweUjpKSE
+        EA2R9soYRZnnBFmipORCYObDp1orYNZ7LEdz6bHySiNiCBNOAKcVBCggZPid
+        eSuC1RB+rQjJhEbx+SAtLGHE+zh9neOGmYDdknvnoOGUscXfS/W69fO9BV4A
+        FrM78jphEarTHjsaXJ9esn1hB3CLlup1lR8WU/SOj6npgiOEPz0pFM9PY8Ob
+        BxmzH3njffyBJo/Z/Y5xLp9lvdRq5HfkqwvNxLcvsnFy9dR5vjo+QlXc2HIv
+        zxNinOfxO05WOeZ3nCY2C42m2ML3p7EXpVGGJYqj1BVwsS3nACEaZw2SkHjg
+        rRSBRzmwWW89XdTrmNEuP0ymoJ/FkqzXeqwIOuHpk/iyc3kEL4/E+f71Ued6
+        T57mh87JaidA53TBGaAT87lYCiMHlAEWWOEME1jheF/HUxO/2RNRJiGzTuXM
+        SomknKtQwnNlnMOBgL0DJi6hUiysTXX8KlQmoIkTaIq1bnZrTLxG2OLAlwwr
+        qKmX1ivqrHRIO84wllq7xaGz6O4KO52ocOwiM8zFnJn9eK3hl25wWKIHVwen
+        J/jxrHjQq5ZbvZslhF9O1js+pKYLjt4Y9mu1Xe/lA87s513ZG5M2r5xdKdNv
+        5uAlOZIRowBNjmNdwJG8fw4Bhois0JGMDk6rd1snfngHjuTZNXs43nmq7eQ7
+        az5Z5Xt0nyo2+5uQdl2vcNGZeuB84XxKHlokKIgPuzLmAhBQGZ/g8MjFaZU8
+        A0QKKoBOJ/hRl5jzwHlG86wlbiC/F+CHX///hEGr7KW/faCeW3uHJ4cntHZc
+        2qGUVfOfo5qsdgJ0TBdcvvPYC46Eo8KBOGUS0AJYE9A+0LJVWhJpGAiLbJee
+        NH0lQasoEHuwB0oQypxR0BHqBJfUCiiUgJSqUCy11syeDkFPRZzJ04dVjqOB
+        3eO3akOEPALEeuCJoC7jHb3TOP54WDgJPxf2u4VU2pnxHFVmR14nyG8Qc2HE
+        3EwS/4LgVEmJXFYS+WrlYB+C+B/lqwtZaKHn4+6z7j0PECxGnZaDQj7kC1mY
+        rHIsZGGa2LxZjVIBcxQ2MB9gOoENhlCGWcwBYLGTgDBhpELOMe9C20gM3Zv8
+        0GOASRcNWMholT+ni3iFFuTPE52A1en1QF9dguv6FfDV3jm+vb27zB/gOlnt
+        hMlwuuAq8i8hIrEFgTB9gCZhvJaWAeukQ9R4RLjklvL1AiYU0BqPNZfWY4aw
+        EhRjZQwxVDKjJLKKSKTTnLKrSR0PQg0xxoglFirnNYIAUUgoJgg6J8JngGq8
+        +KmoypMLS/pSvauiSOXyFGd35HUCJj2PID2p6Dq8vm934Fb5TPYRzA+YKXrH
+        x9R0wTfpK9uF7ajTbObDzOxH/vE9mX/aqWL2wFhKqBwdeskbi1A95hADEVai
+        q8sN33lG5VJRyavjaheWn3rF7cPmVb7c8JNVvsfMqWLzvdo9NUGUHH0xX9pM
+        iRUhPpjn2EtCkRXx4Y34tXgQeaAYQDwm0Awv5sJZ4TPa5M8JmaterK7ccqwY
+        L7fv+xfD3tHtC96VL+3rHooO7vL7L1PUTsDL6YLLx0sHPeGGizDMvPFGEwKV
+        4lJSTTHE0kqmqCYqfXt9NeenqNGcEkyEdtxRpbHVRispLRc2sKanENjUnKMr
+        wUsYyoAE51QmUbBxBD+xSFoXJ/wVoUSMceQkXRwv97ZKN9eXubgyswevkyvR
+        dbv9/OXleed2VzyWz+5Vo9M4O15CWvTJescH03TB14o/1XVXuIjqJqf/MvuZ
+        f3yw/BNOD++RcgSNY5lHwzpx8rH6BbbIA1GCeMudrm6LnLbuWu324PgyGkQC
+        IHV7dv1gv+R7++Vkle+JcqrYcoiSLJpyFGLIJXbAeoniN5Baqji3WlKEGZLO
+        Es1hnOkwI7J1tCU/50swMxrldfx/aNZbX3sW+nafD+3QKaY1UtepyNT+/th3
+        0fBzUn1/javvY8f7rut9RuBjojf+IS7056REH7/al8/xMP96q6/i8c3+uHlS
+        b51+0hfb/Wbz28e9Tk8l1Y0Rg+Gjf/7ln/8PAAD//wMApY2n/cXTAAA=
+    http_version: '1.1'
+  recorded_at: Sat, 14 Feb 2015 18:02:17 GMT
 recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/track_search_Wanna_Know_offset_10.yml
+++ b/spec/vcr_cassettes/track_search_Wanna_Know_offset_10.yml
@@ -233,4 +233,212 @@ http_interactions:
         AAA=
     http_version: '1.1'
   recorded_at: Fri, 15 Aug 2014 20:05:28 GMT
-recorded_with: VCR 2.8.0
+- request:
+    method: get
+    uri: https://api.spotify.com/v1/search?q=Wanna+Know&type=track&limit=20&offset=10
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      accept:
+      - '*/*; q=0.5, application/xml'
+      accept-encoding:
+      - gzip, deflate
+      user-agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - nginx
+      date:
+      - Sat, 14 Feb 2015 17:59:39 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      keep-alive:
+      - timeout=600
+      cache-control:
+      - public, max-age=7200
+      access-control-allow-headers:
+      - Accept, Authorization, Origin, Content-Type
+      access-control-allow-origin:
+      - '*'
+      access-control-max-age:
+      - '604800'
+      access-control-allow-methods:
+      - GET, POST, OPTIONS, PUT, DELETE
+      access-control-allow-credentials:
+      - 'true'
+      content-encoding:
+      - gzip
+      x-content-type-options:
+      - nosniff
+      strict-transport-security:
+      - max-age=31536000;
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAOydaXIruZGA//sUDP1o2+F2P+xLR3Q4SInaqZ3axhMdWMV6
+        4iJxkUg5fI+5wFxhLuCLDaqklvSkquJSJK1+Vkd0xROZzEIVgMSXCSDxjz+U
+        Siv9rjLXvZXSz6V/hD/DB42u8/GfK41+/6b385cv6ib6qXfT6Ud+9JPptL7c
+        wS89p7qm8bfbgeuOfjlT7bb6y067c/9Dx/ue6/8CwQ/NqBX1f0Hgh/7oxv2S
+        3GTlx8cbRH3XSm74X0+3DJ+pph60Xgrx8tmv8e+T4jyK/Pjq+zsVNZVuul9b
+        qnvt+k86V8prKz+G61FyPUmu9fhaqSbXjeS6n1wTmdXN5LqbXJPPVx8/v0iu
+        l/F1Lfnt2k5yTWSqq8k1+bx6HF/Xt5Jr8tuNSnJ9/HdShs3kt5t7yTUpz1by
+        263kt1uJzG6iYffx34nM7ml8rSX3qiWf7yUye0lp95KS7CUlPCgn10TnQfJE
+        B4nMQfKrg+RZjhL540TmOHkPx4m246Rsx8m9Ts7ia/1ipfTfr961G/Zdt62a
+        vw66zd639RS+fWod37Sazo1rf9Nskvr7gle/Dk5G/d3LB7whH9rnfdTdvqqv
+        PGv756ubTtISE629LLWvlEU2UTWBYEtduTft87E4Lrpq9OMvGAE/vv4mvJRv
+        yhlKaWw7FPFLouyLg55wwwXi0BtvNCFQKS4l1RRDLK1kimqizMo3Wu8j2288
+        3e7V+8kqFAbTFYpAajSnBBOhHXdUaWy10UpKy4UVFHsKgdUwo1DhdhMUipGp
+        ygRDGZDgnEqhkdTQa0AsktZxRo0IJWKMIydp5ot6KdI3zbetWo9G5HizvHZx
+        fvq6vrMNzKAbJV88NbmfE4Gf81vwc/tdUd1+1Ou/a0hz6UqJ6i/ovN0eHj4M
+        1y83xG314Ku67lwf1Ar0pccSZ+l935nGCz6/+H0dudJJNzIu/d0nt859+YnE
+        z/nP/KrWP4eHZQ0PKzbqmV/bg5Z23fgdo5cvBl3VjzrtXx/He0QIxfj5Wze8
+        aUYmSuxEvztwr7546iGRfdNBVqJe1yTNon5cr3FAAWJUvu97OX1ssh6WAMsX
+        2rpqtdt3tdPuXVcApC4Pzm/s4fvbTdK5HjkrS+WzqqeeNVas9+tNU43i5v3u
+        9T33uQTMSjGYvfzwpnMzaKpu1E9eAGEvX3TdXeTuf31rom+eTXTrBv/1SeoL
+        xJBL7ID1EgEQhjCqOLdaUoQZks4SzSFyArzcOHn+V60EgpevfrMCrzExxQQk
+        X/+cVymvBqJJkLIXta+abiFMWf79mY7aeXK9WIoZOVoCa5Iz+PXr8H7NXtFq
+        F57B7a26Zrgwa2aofT88TiA4f9aUlBCiIdJeGaMo85wgSwLVcSEw8+FTrRUw
+        ZKmsqbn0WHmlETGEiWAYnFYQIItZ+Jt5K7AkwmcVaiGsyRLEdFgLSxjxHnFM
+        HDfMIOIk985BwwNvZkP5ONa86AxKKSZ4BuTMb8jLRE6o9vts9+58/5RtCXsH
+        y3QtilRx5MzQ+75PjRd8fv9r+3ulytF+bHiLEGf+Iy+EOD8Hj9kGj7ckCjNJ
+        NCALewGQ1yTqVbM3HYpuVMpHuxADCDhcGIriywd5vXd23xme1XZRHV+X3cPQ
+        F0LRDJVvUXSs2CQommEL3+Aofamw6XCUYYkMokYBF9tyDhCiSBEpIfHAWykQ
+        dhxYlIOjM9JoXr1MSaOLC3B+2pN/P4zir3eVg+2yqoy6J27vunp1d3/pBsUD
+        n+lqUwKf4wXnD6NIaeok415ILgHiXjuuHKdAKKUQZF4Kp7WVS4VRoAW30Guj
+        sCbaCwWtx9p7Jg2RQGBtAGZYq2XCKAovAzEtrSHISCXCO7IUK8QDkAIoEPGQ
+        41C8mWF0r1OqjfqNTrNzFbleqd8prXeazc596U9rrjkYuj8XConmtu1l8inQ
+        1kdqdFjecfe31TtVZ93z1bvifJqh9303Gy/4XCW1f/1PMTLNf9hPMv1AI8nk
+        ZEoxFC9RuXmRqVhckJRU2vL6ol+RbE/dXNHr0aEfmVYhMs1Q+ZZMx4pNQqZ7
+        7s51J2HTF3dhOjZVShjrNHIUGMONglppT2gYcxy0YaTxVFrFHc9m05eQ+XRs
+        mlczH4ZNP44t+fhWZJ48Cjb0Bm1dHK9HEuz3LkZ10lhfXy3MoxlqUwbK8YLz
+        51FGFeNEE2Kc5hpgzCUMHEos80RThAlSFknhl8qjlDgDJIQOGgkZNNo5zAF0
+        ykgDuGKUe8egF8vkUUziN+OINBw4jil3kkMlsUYMQkopADB86LNf1DgeLbdH
+        umNHT4a3MhiVyqVNF8Dmb0VANL9RL3Vuvuv6J7y2fr+5dnriNnbW7EhXh3OY
+        m0/XmzI3P1bwuS52firVItNwzW/nwmaYnM996O98cv7jDx+TQyikeG4QWj8u
+        nwQTCwiVCwyP7rS2d6JLo9twfdfeHvW6dnN1o1h4NF3lu/DoOLFJIHQzOOJr
+        nVIcJY0Z9G9ZEEpmDZByIRShTECouRKWeq+QNl5JgQDxmlgvjJYgZ76ezhog
+        zamZz+n636Nfe7xQLsW1u/LJxWj1/Kp1t3+rzr7eHcrOSfE4abralDjpeMH5
+        cykHyjHGNREwEJcTBBvIFfcGAEeQ5EIzQJxyS+VSg7WmHEGrANVcUuGgwFoZ
+        7KkRVgJKGBcE2GVyqYKGGhZsGOBSBDKVGnAkMKfeSGSBUhJJLXj2ixrHpZXo
+        OmpHpTX14ErVg0JB0dyG/BkU/QyKfg4eST1MERpFMH356AcNjWK+sY4anbPV
+        1Y36Fmqre3R5enlfjErTVb6j0nFi8wyNEjEjlUrGEdACIWWkDBcqw5+IM8x9
+        gFLjvbPMQiOyqfRlrfGUVJpTM59U+n0YlnlSKW+cn8pRb3Dq22e3FHXFduc4
+        FKgolWaofT+CTiC4gG1LmAqALTUAhr7JjSEMcmZdIC9uiLQOaceIQ0ulUoEd
+        VZYZzBlFTnmCoNDIW+NcgEHINIqDuGKp0VLKICYE+OBaI6YACcBsvdZQCYGR
+        QRh7az3GWSsKxlPpiw1OYgTFwDS/LS8VTHfwiLf3BvfXlye7W4PDh6vzg+7F
+        HMA0XW8KmI4VfFlNGnWd6Rdk09zn/aY5zjMUTfbFev+BlW91ZxXX1b2O7kl3
+        DqHodL0poeixgq8CYc3mqLTWHbRanbYt9rbzn/vTE/hwA/bkngADCMxr+e5q
+        ma0hCADAiCzOEzgeXvZXD8py+7Lj2hvbV7vipNMp5gmkq3znCYwTm24nWTL+
+        /Mk71f+p9G1n/XOme/ASOp7OPSDCxaO5BQAxphCy1gqlHDSIeiqVYt4YbyTM
+        dg9mXtWbU11LdA/+c+zM79AlIBv17cvr64cuJBVevb2P2NGaqBTfXZau9v2o
+        OoHgAhb0UgCFAAGwg7MuMIQcIW8cs4hhBg1gnHsAzHJdAgehhtJKwUggboiE
+        xUYqQnEop8EaMg9QcFSWurtMEaAkdRRD67jl1kDmhHaSS4VjIwaItVoRPbNL
+        sNYpbb2KzRRaNpHflJfpEfDdtgDN+jHbdICf321uidvbzc3irJqhN8XRHiv4
+        soSla/qRKdU67Ws36hVj1fznno1VP0ePfxufckzQs70oHKlercaRaoAxWhif
+        gu6R7K+6y4uoLqKbcm13eMYaqhCfZqh8y6djxSbh00xjOK9FvFAQSmQY4oTQ
+        UksiuPeWKKgllsZjILAjnPEFoGhezSwORTPc3CejMa25mMRQZJiIR4PwZAQK
+        O6lP3f+3Lr+glbU77Lx+cDyqbwzvOlfmrtYags0iaXmeVtamq00Lao0VHA+G
+        lMGpeCeOvAbcAg7H+5W4lMpq4YkyllGrBAq9RxpGWSEwDJA5XazYUoJVjIHK
+        WQWxD2SoJQ9OZZwOgUiDkIIcZEHYZGBI2VRlkji8FEOBdFLiwMsI21Agamn4
+        lyIBFZlhhqustFvjwXCrtD3o9V9Zw9Kfzjqd68iVyqYTvomRJRoW2u+V38KX
+        yYusti79Q6Xlz68a5QdJsXloVYqsYn/ixQy97zvbeMHnijlRUae02h08FEPF
+        /EeeCBX/06z75OCGEJhbYHGjEqeoYoACLhYGbugMqMbt6c1W/8Li083NE8Ps
+        XbEUVRkq34LbWLFJwO29sfprKcVaZfEcnpXnPJccUciEF0ICDsLw5ZWXjDGI
+        LBXGOEe1eLW2bW48l1dhy9iUNQev8NMffH7jc4NG9jBY3VbD1ubO3s4ebdTW
+        1illxfOiZqhNGcfGC84/mugFR8JR4QDxUoK4wxnkALLMquBkBWAE1CiXHSRb
+        yLJXhDQAVKrg8jFnFHSEukC01AoolICUqlAstdT0AA5BT0WcDsB7ahxF2inN
+        EUTII0CsB54I6uDsCwxqo9Je+Hdpq1fa7mTsApqMDfMb8jLZED+c7DtY6Y9O
+        ru/37i4u94fn1/3z4myYofd9nxov+Pz+M1/6pFSY/7DTBhA/B4l/Q9BQBh+Z
+        z4k968fbW/GcdjBkfGHsCVtoWOsNdX94h2Cl22k5KORNIfbMUPmWPceKTcae
+        E+z6f4niTgeYTmCDIZRhFHMAWOwkIEwYqZBzzLtQNxJD9yrJzNw2XOXVyofZ
+        9f/dTUEsJMvyYpETwG70ILdrNwd2V0p/0ehcqptG8ThlutqUOOV4wQmQE/Gp
+        SIo4wqljSlFrCVAIM4OoYI5Z740ijuF41TktloofySnxzjOoANZQABgQzxkm
+        DQiGQlIETQBKCz0DRBZc0zpd7BQYAqVg2jirhWEmWDEMCUEEJnPZcSHDiGVn
+        j1OeNVzXPU/bVApBZ35TXiZ00p2924tudLd3dbq6Wen1qvXjAS2yKuQJOjP0
+        vu9V4wVfzZq1XbMZgL/tCk5f5z/1oha2MmJMV9l7cVU+bMur2uFlq9qYQzLa
+        DL0pTvNYwed3vRv1VOnvK7vO90vVkfv7Smk3PFbB157/Aj5XuH6ggXtyN4Bg
+        Pr9DEnbXkZQAILC4pa30oLbz0Kv3Tm4uLzd6q2a7MmgcpKxUmOaQhHSVb72A
+        sWKTeAH1x7DzWUP1/9gr1W8yPYEX12xKTwBqaLEwHvvAGlALwiQQLN6nCp0k
+        lGlFNaN5RyXMmgAsr2oW5grUX9mAnZde/tSb62977WPvfOyRT31ra1HAO2wN
+        8Galj6q32+p+o6aYrn49LA686WpTgHe84PxjrMALbiCljKDwH6cKK4SICDQH
+        JKXcAUQJC1C31Bgr4uG/UA5vQQBbrwi2DCmOhEHAIWA41Fb55aa8kt754AO4
+        +DgsADQm1jmr4jArR1j6eBWp1SyzTBNMzMcGplw6ce1eX5VOGlH7qhDz5rbm
+        pTLv1mqLoEPLasNB+wYOR5WN+g2YA/Om601h3rGCL4s2rWo9VUFB5M196Mmn
+        4edmKScnDBx7dnMKNB5XL852IIwRY3GT3HBzf29L1hqEdF0fHx5G/LDf/1os
+        0Jiu8l2gcZzYJIhx0nCjCWKNaNbDmOIdptBKb7kVlAe75YM5BYkVpRASQxF1
+        XL9ae/WOMF5aw5SxxpyK+dxG/3vxWZaRbpTtXR4cRPXbxsH2OToBbTU6PnVr
+        xee309WmuOrjBefPXsRZDQlAHgaaIRZxbWV8KpqhmkMApQKEB8DInrZdSLpR
+        S5UNZIOxIYFsAhkGs8E8gY5giY3UhkGhDV8me3lMKPIcSq2lRxYyGVCQUQi4
+        1s4BK6TzShcINj5vXUzMcKH57dyGvNS1j9sN9fD1bu+MYTWiF8P1AbBf0RzC
+        X+l6U/rUWMHn94+7tlS1VwUnufOf+DPe9YHGjolpFErC+BwT3l9UA4pCJhZH
+        o6B+y8+JHAHRwutiVIOWHe2m7JabZq9Musq3NDpWbBIazTCFbzdtz7qyUnrC
+        g+9Mg/dMPdYgdqgt5cJZK7hFzhuohHp11vX8dsrk1MviYPRoAiOSaz6eDMfk
+        JuOdsZgoGfFrczDx+pdnN/PHBe6XYQ/9g5E8oeWvUIg22S6vbtCz4icjZahN
+        GcbGC06Ahng64gFEe4skdAYyogEjhnFPMcHMIwSQNMgCDlCxsBySU06OM+U4
+        IFBh5jCkEHniPScQUeohItJDQoIjmZX1fSHz0NgoBTxxniiEw8tS0gmsMQw4
+        zbxTFlDpFMrM9zTJfpm1TvuP/Tkd1ZnfmJeJh6SydViWd0fXt+fVdhn171u3
+        vFVkRfETHmbofd+vxgu+LD8N406ndBa1VbvglGj+Uy9sJnrQ6TeGtTO3e7bV
+        6G24dW5GHTIHFE/Xm2LDxgo+v+tqe1Qw9Jn/tIt6x1Te++tBpbM3aqzVDjdW
+        m191XZfnEGVO15sSZR4r+CpZmLWjgvHl3MedyNf5z0STKfLJCjG3fLL140qF
+        AAJA+H9xWaTWLtDFxWr7sNfD4dPe+rqqmN1iWaTSVb71PMaKTbbg9u1IW/pr
+        qaai9ty36zsqAQXKKIm01oJjKAMuBPfDKIq4IgwRLzEn83dC8qpowatv3yX9
+        +CZ4kRGqmCQ8USQY8c2K+1ed+JvgwquwwsnRgrwMxOXO8B7USLlKqxKpLX3X
+        WHeFvYwMte9HjwkEFxCA5oISjDzg0jDPmccMEOoAV5qG7yR2lHODQCEvY+rz
+        Vzkz0gEjFPLMUU/iHElx1n7iuXWCCc6l02ypk/+AKGccgzA4OwxjFMpoKWTe
+        s/AnQThOGKA4y35R47yMo465VjqKE+YdOe2aRXyM/Ka81C1WplaN1npDeXqz
+        cbfOYaO+0bs/nsMWq3S973vVeMEX7rU2cqWas4OHgvyb/9RThKG/P4s9RdiX
+        EzSvsO9x9eCwBkLvlWhx8EUOa7ft3WqHnm3Yq8OabZH+5fZ5IfjKUPkWvsaK
+        TQRfPgn6HjkV26AJViPMmtTfOwqhYlwK7KTSQkJvINPBoAIZBhxkOUAeu7z1
+        jrNm9c+roqXsrZ/tZLpJkmlMMEP02Lm/mQl651ktaPZnQUdBbQnTQreyJ+zg
+        ilWG1KzKM1P8KKh0tSmDy3jB+SMbRNYCRV2caTPYMxKgREvrKfAGYCpo6FhM
+        Wb3c9ZoEMmK9gsRhAq21MbYJyKnFjITyUUcgDKVbaoZNLpWkSmir4kOqBFHC
+        xxmCLdWhTJYGLw/xUMjsjFPjkG3N+dK2apUQ/bF02mn+VBI/lzai0KZf5Swp
+        gnH5zXupWTcH3Vtw6m+H1YtqNbqsXzt9fjKH8GWG3vc9bbzgc61AiIrRW/7D
+        Tr1T/tPkT8F8goj07EozbG1Z20YgPocYLe78JlhvVWR03TqKmpej1Yeja3C6
+        SVImc6ZZd5qu8i3yjRWbbGtLudl1yo7yT2+a9UxRIpRWWmpPoYZeA8WgDQDu
+        pcOSeImww9oilXN608vm+imXnebUy4fZ4j7XNUMLXC30/awxxWr//E6fnYLz
+        6Az4ev8IX15enRbnxXS1Kbw4XnD+vBi6HJHYAuGAp0gL4wMuMmCdDAhpPCJc
+        8kBDy82hBAW0xmPNA7lihrASFGNlDDFUsjgqbxWRSGftsl8ILyIQ3hBjAWSJ
+        hcp5jSBAFBKKCYLOifAZoBrPfnTo8b1z/dJa1FPdrsqY/ZuQDHMb8lK39hx1
+        Id071hE8/9ruwHL1QA4QnMOka7relEnXsYIvvK7apdVup5kRW5144jX3kT/+
+        Ifbf7VAxOWdSQuVLDGkOWTwhBgKixaVfJ50hqq5VlDyr1Xuwet+vrO40z4rF
+        FtNVvostjhOb7nigLMjEckbIxBIrQnwwz3EiQIqsiGMh8UkfEPmAnADxOMmS
+        zobMWTdP59XJ5xlAv9+EbPMkzs8zgD7PAMou0+cZQM/fThWN/DwD6PMMoI86
+        ekwOoYQJMa90ni9nAEm2uEQ+6D74rj2w9rVyfbp+cM16p+fXuFgin3SVbyF0
+        rNgkEIoAxFn4SV+8genwUyhhjZEAKSI9EtRLhghiQMXbmSgzjjuigJHZ+Dnr
+        XHZebXyfMc4p7MfkluP3PQNO6leN3vq65YfVw/PtEe3DdbhffAY8Q20KX44X
+        nP/WqODPcaeUYZZAQyQMgEk5sIZT75WKz6FHjBpRbNHitFuj4iScofvHM9+h
+        cN4LH5zOZAM/xsQqqiVElhWNaE65NQpyb7x0XhpOmCNaWKiw4gRSRa0ADiGh
+        DJYz8+WxM522LR11Bm3bK+23S7VCWTrzW/MyEROdt9vDw4fh+uWGuK0efFXX
+        neuDIkd0/XYkerre9x1rvOBzJezryJVOupEpuHk+/5k/flzzOxkepkkECVj6
+        CskZZsvjo4goCIZzcbPleP/4BPU2m8MNpAbnfPfgIdpvFsvSlKHyLT+OFZtT
+        EPMllDgdRcaEaDyAwAXXX0hNlKEkjpgIwBxTlnsLDLB0/jPleXXyYSjyu/NF
+        FzghsuCU8F/xDTzu+JtTW7/s+sb2ua7sDotnyExX+35YnEBw/vFMBwXnSmsk
+        ggsZSJNB5ZANfRUCzqgnngnEnM6eGF7IiktmIQAQem2dksAjBp0gGkkSrt5B
+        xKS1yhc7unLaDJlBK7BYKQgQsF4JLCgU8cuhJE4cRVXMnCQrPcAk8cxWyf7r
+        f7vquh9dqV7fleyg1XBJ4y7Z6Crqq2a/9Kejf/3fnWuXULEzLHOb+ucmmt/N
+        JprPceaDRT4RxojM6xDN42plowwYAAgtLoU54I0G3S1HrNk/ue2Pqmu9zXq3
+        YEandJVvyXWs2HTkWnrc5ZO5p2fW04ywZsAiSLWVBASAxQ5wqrmlgkBlHeRQ
+        A46EzwZYOHNWp5y6WfqG6lcb86bdkjeHzXgnT314MexHjwe9I7qn4WC0qzej
+        rS7s32wfFGa/DLUpK73GC86f/eI0uRRJoePjdWKHGziCtKcWcuYsgNIrGiBn
+        ubttrLaUEM8hgUZjgRXCVikWwItIYjQkLtCqw1nZMBfEfhYQLbDVSBHhMcCW
+        WsmJjSfaoREcYkawnX315GZsxBrxTGpfBWuGS/vdAHyhYZeO4/Djt7ZiBt7L
+        b95Lnd9u10mjAgi4Omlttgi9uKjd3RYJ6v82v52uN2V+e6xgRq0UnN/Ofe5F
+        pQ1Cq7JN+odXe7uNzYPG8WrL9g7b13MI9abrTQn1jhV8tYL1LrKlctc0Bk1X
+        NEF9/oMX2qX+0YbBySflGc+Kqc6S8udsDQKJGeZ0YWjK+Y67a+i98mFjUCbV
+        9nEd2bMUN3UKNM1Q+RZNx4pNe8ZmHpniWSfoPeaEYMQpMAQrYeLoDbVAA0QY
+        kZoD4R32ebvNX5rDdGCaVzPPvWulGbUe2xd6YoCVdmgZ42qq51QwAn+7Hbju
+        6JfkDf4lfoM/dLzvuf4vGPyQ6P0FgR/iQv/yusArj0JJc//tnsnb6gx6Be+b
+        e9t+p6+SGgsgwMNH//zDP/8fAAD//wMAYHRfmWHUAAA=
+    http_version: '1.1'
+  recorded_at: Sat, 14 Feb 2015 17:59:39 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
To account for searches containing [percent-encoding reserved characters](http://en.wikipedia.org/wiki/Percent-encoding#Percent-encoding_reserved_characters) like "Belle & Sebastian", the CGI.escape method can be used instead of URI.encode.

This method can safely be used as the Spotify docs claim that a `+` can be used to replace spaces in URLs in addition to `%20`: https://developer.spotify.com/web-api/search-item/.

Here is an example of the difference in escaping between the two methods:

```
2.0.0-p598 :001 > require "URI"
 => true
2.0.0-p598 :002 > URI.encode "Belle & Sebastian Florence + The Machine"
 => "Belle%20&%20Sebastian%20Florence%20+%20The%20Machine"
2.0.0-p598 :003 > require "CGI"
 => true
2.0.0-p598 :004 > CGI.escape "Belle & Sebastian Florence + The Machine"
 => "Belle+%26+Sebastian+Florence+%2B+The+Machine"
2.0.0-p598 :005 >
```