### PR TITLE
Artist json conversion

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
+gem 'json'
+
 gemspec

--- a/lib/rspotify/artist.rb
+++ b/lib/rspotify/artist.rb
@@ -6,7 +6,7 @@ module RSpotify
   # @attr [String]        name       The name of the artist
   # @attr [Integer]       popularity The popularity of the artist. The value will be between 0 and 100, with 100 being the most popular
   class Artist < Base
-
+    require('json')
     # Returns Artist object(s) with id(s) provided
     #
     # @param ids [String, Array] Maximum: 50 IDs
@@ -106,6 +106,42 @@ module RSpotify
       return @top_tracks[country] unless @top_tracks[country].nil?
       response = RSpotify.get("artists/#{@id}/top-tracks?country=#{country}")
       @top_tracks[country] = response['tracks'].map { |t| Track.new t }
+    end
+
+    def to_json
+      {
+        'external_urls' => @external_urls,
+        'followers' => @followers,
+        'genres' => @genres,
+        'href' => @href,
+        'id' => @id,
+        'images' => @images,
+        'name' => @name,
+        'popularity' => @popularity,
+        'type' => @type,
+        'uri' => @uri
+      }.to_json
+    end
+
+    def self.from_json(string)
+      loaded_json = JSON.parse(string)
+      json_sanity_check(loaded_json)
+      puts loaded_json
+      self.new(loaded_json)
+    end
+
+    private
+    def self.json_sanity_check(json)
+      json_clone = json.clone
+      fields = %w(external_urls followers genres href id images name popularity type uri)
+      fields.each do |field|
+        has_key = json_clone.has_key?(field)
+        raise(ArgumentError, "JSON input string is missing #{field}") unless has_key
+        json_clone.delete(field)
+      end
+      unless json_clone.size == 0
+        raise(ArgumentError, 'Invalid JSON field detected')
+      end
     end
   end
 end

--- a/lib/rspotify/artist.rb
+++ b/lib/rspotify/artist.rb
@@ -1,3 +1,4 @@
+require('json')
 module RSpotify
 
   # @attr [Hash]          followers  Information about the followers of the artist
@@ -6,7 +7,6 @@ module RSpotify
   # @attr [String]        name       The name of the artist
   # @attr [Integer]       popularity The popularity of the artist. The value will be between 0 and 100, with 100 being the most popular
   class Artist < Base
-    require('json')
     # Returns Artist object(s) with id(s) provided
     #
     # @param ids [String, Array] Maximum: 50 IDs

--- a/lib/rspotify/artist.rb
+++ b/lib/rspotify/artist.rb
@@ -126,7 +126,6 @@ module RSpotify
     def self.from_json(string)
       loaded_json = JSON.parse(string)
       json_sanity_check(loaded_json)
-      puts loaded_json
       self.new(loaded_json)
     end
 

--- a/spec/lib/rspotify/artist_spec.rb
+++ b/spec/lib/rspotify/artist_spec.rb
@@ -164,18 +164,18 @@ describe RSpotify::Artist do
     end
 
     it 'should convert correctly to and from json' do
-      reload_once = RSpotify::Artist.from_json(@artist.to_json)
-      reload_twice = RSpotify::Artist.from_json(reload_once.to_json)
-      expect(reload_twice.external_urls['spotify']) .to eq      'https://open.spotify.com/artist/7Ln80lUS6He07XvHI8qqHH'
-      expect(reload_twice.followers['total'])       .to be      > 0
-      expect(reload_twice.genres)                   .to be_an   Array
-      expect(reload_twice.href)                     .to eq      'https://api.spotify.com/v1/artists/7Ln80lUS6He07XvHI8qqHH'
-      expect(reload_twice.id)                       .to eq      '7Ln80lUS6He07XvHI8qqHH'
-      expect(reload_twice.images)                   .to include ({'height' => 1333, 'width' => 1000, 'url' => 'https://i.scdn.co/image/fa2e9ca1a27695ae7f8013350d9a53e11d523ece'})
-      expect(reload_twice.name)                     .to eq      'Arctic Monkeys'
-      expect(reload_twice.popularity)               .to be      > 0
-      expect(reload_twice.type)                     .to eq      'artist'
-      expect(reload_twice.uri)                      .to eq      'spotify:artist:7Ln80lUS6He07XvHI8qqHH'
+      require('json')
+      json_hash = JSON.parse(@artist.to_json)
+      expect(json_hash['external_urls']['spotify']).to eq('https://open.spotify.com/artist/7Ln80lUS6He07XvHI8qqHH')
+      expect(json_hash['followers']['total'])      .to be > 0
+      expect(json_hash['genres'])                  .to be_an(Array)
+      expect(json_hash['href'])                    .to eq('https://api.spotify.com/v1/artists/7Ln80lUS6He07XvHI8qqHH')
+      expect(json_hash['id'])                      .to eq('7Ln80lUS6He07XvHI8qqHH')
+      expect(json_hash['images'])                  .to include ({'height' => 1333, 'width' => 1000, 'url' => 'https://i.scdn.co/image/fa2e9ca1a27695ae7f8013350d9a53e11d523ece'})
+      expect(json_hash['name'])                    .to eq('Arctic Monkeys')
+      expect(json_hash['popularity'])              .to be > 0
+      expect(json_hash['type'])                    .to eq('artist')
+      expect(json_hash['uri'])                     .to eq('spotify:artist:7Ln80lUS6He07XvHI8qqHH')
     end
 
     it 'should convert blank artists' do

--- a/spec/lib/rspotify/artist_spec.rb
+++ b/spec/lib/rspotify/artist_spec.rb
@@ -4,7 +4,7 @@ describe RSpotify::Artist do
 
     before(:each) do
       # Get Arctic Monkeys as a testing sample
-      @artist = VCR.use_cassette('artist:find:7Ln80lUS6He07XvHI8qqHH') do 
+      @artist = VCR.use_cassette('artist:find:7Ln80lUS6He07XvHI8qqHH') do
         RSpotify::Artist.find('7Ln80lUS6He07XvHI8qqHH')
       end
     end
@@ -23,7 +23,7 @@ describe RSpotify::Artist do
     end
 
     it 'should find artist with correct albums' do
-      albums = VCR.use_cassette('artist:7Ln80lUS6He07XvHI8qqHH:albums:limit:20:offset:0') do 
+      albums = VCR.use_cassette('artist:7Ln80lUS6He07XvHI8qqHH:albums:limit:20:offset:0') do
         @artist.albums
       end
       expect(albums)             .to be_an Array
@@ -33,7 +33,7 @@ describe RSpotify::Artist do
     end
 
     it 'should find artist with correct top tracks' do
-      top_tracks = VCR.use_cassette('artist:7Ln80lUS6He07XvHI8qqHH:top_tracks:US') do 
+      top_tracks = VCR.use_cassette('artist:7Ln80lUS6He07XvHI8qqHH:top_tracks:US') do
         @artist.top_tracks(:US)
       end
       expect(top_tracks)             .to be_an Array
@@ -43,7 +43,7 @@ describe RSpotify::Artist do
     end
 
     it 'should find artist with correct related artists' do
-      related_artists = VCR.use_cassette('artist:7Ln80lUS6He07XvHI8qqHH:related_artists') do 
+      related_artists = VCR.use_cassette('artist:7Ln80lUS6He07XvHI8qqHH:related_artists') do
         @artist.related_artists
       end
       expect(related_artists)             .to be_an Array
@@ -56,7 +56,7 @@ describe RSpotify::Artist do
   describe 'Artist::find receiving array of ids' do
     it 'should find the right artists' do
       ids = ['0oSGxfWSnnOXhD2fKuz2Gy']
-      artists = VCR.use_cassette('artist:find:0oSGxfWSnnOXhD2fKuz2Gy') do 
+      artists = VCR.use_cassette('artist:find:0oSGxfWSnnOXhD2fKuz2Gy') do
         RSpotify::Artist.find(ids)
       end
       expect(artists)            .to be_an Array
@@ -64,7 +64,7 @@ describe RSpotify::Artist do
       expect(artists.first.name) .to eq 'David Bowie'
 
       ids << '3dBVyJ7JuOMt4GE9607Qin'
-      artists = VCR.use_cassette('artist:find:3dBVyJ7JuOMt4GE9607Qin') do 
+      artists = VCR.use_cassette('artist:find:3dBVyJ7JuOMt4GE9607Qin') do
         RSpotify::Artist.find(ids)
       end
       expect(artists)            .to be_an Array
@@ -76,7 +76,7 @@ describe RSpotify::Artist do
 
   describe 'Artist::search' do
     it 'should search for the right artists' do
-      artists = VCR.use_cassette('artist:search:Arctic') do 
+      artists = VCR.use_cassette('artist:search:Arctic') do
         RSpotify::Artist.search('Arctic')
       end
       expect(artists)             .to be_an Array
@@ -87,19 +87,19 @@ describe RSpotify::Artist do
     end
 
     it 'should accept additional options' do
-      artists = VCR.use_cassette('artist:search:Arctic:limit:10') do 
+      artists = VCR.use_cassette('artist:search:Arctic:limit:10') do
         RSpotify::Artist.search('Arctic', limit: 10)
       end
       expect(artists.size)        .to eq 10
       expect(artists.map(&:name)) .to include('Arctic Monkeys', 'Arctic')
 
-      artists = VCR.use_cassette('artist:search:Arctic:offset:10') do 
+      artists = VCR.use_cassette('artist:search:Arctic:offset:10') do
         RSpotify::Artist.search('Arctic', offset: 10)
       end
       expect(artists.size)        .to eq 20
       expect(artists.map(&:name)) .to include('Arctic Flame', 'Arctic Night')
 
-      artists = VCR.use_cassette('artist:search:Arctic:offset:10:limit:10') do 
+      artists = VCR.use_cassette('artist:search:Arctic:offset:10:limit:10') do
         RSpotify::Artist.search('Arctic', limit: 10, offset: 10)
       end
       expect(artists.size)        .to eq 10
@@ -111,5 +111,84 @@ describe RSpotify::Artist do
       expect(artists.size)        .to eq 20
       expect(artists.map(&:name)) .to include('Arctic Queen', 'Arctic Sleep')
     end
+  end
+  describe 'Artist::from_json' do
+    before(:each) do
+      # Get Arctic Monkeys as a testing sample
+      @artist = VCR.use_cassette('artist:find:7Ln80lUS6He07XvHI8qqHH') do
+        RSpotify::Artist.find('7Ln80lUS6He07XvHI8qqHH')
+      end
+    end
+
+    it 'should correctly load an artist made with the .to_json method' do
+      from_json = RSpotify::Artist.from_json(@artist.to_json)
+      expect(from_json.external_urls['spotify']) .to eq      'https://open.spotify.com/artist/7Ln80lUS6He07XvHI8qqHH'
+      expect(from_json.followers['total'])       .to be      > 0
+      expect(from_json.genres)                   .to be_an   Array
+      expect(from_json.href)                     .to eq      'https://api.spotify.com/v1/artists/7Ln80lUS6He07XvHI8qqHH'
+      expect(from_json.id)                       .to eq      '7Ln80lUS6He07XvHI8qqHH'
+      expect(from_json.images)                   .to include ({'height' => 1333, 'width' => 1000, 'url' => 'https://i.scdn.co/image/fa2e9ca1a27695ae7f8013350d9a53e11d523ece'})
+      expect(from_json.name)                     .to eq      'Arctic Monkeys'
+      expect(from_json.popularity)               .to be      > 0
+      expect(from_json.type)                     .to eq      'artist'
+      expect(from_json.uri)                      .to eq      'spotify:artist:7Ln80lUS6He07XvHI8qqHH'
+    end
+
+    it 'should error on empty input' do
+      expect { RSpotify::Artist.from_json('').to raise_error(ArgumentError)}
+    end
+
+    it 'should error on invalid input' do
+      expect { RSpotify::Artist.from_json('{}').to raise_error(ArgumentError)}
+    end
+
+    it 'should generate a valid artist' do
+      related_artists = VCR.use_cassette('artist:7Ln80lUS6He07XvHI8qqHH:related_artists') do
+        RSpotify::Artist.from_json(@artist.to_json).related_artists
+      end
+      expect(related_artists.size).to eq(20)
+    end
+
+    it 'should fail when there is extra data in imported json' do
+      json = @artist.to_json[0...-1] << ', "garbage":true}'
+      expect { RSpotify::Artist.from_json(json).to raise_error(ArgumentError) }
+    end
+  end
+
+  describe '.to_json' do
+    before(:each) do
+      # Get Arctic Monkeys as a testing sample
+      @artist = VCR.use_cassette('artist:find:7Ln80lUS6He07XvHI8qqHH') do
+        RSpotify::Artist.find('7Ln80lUS6He07XvHI8qqHH')
+      end
+    end
+
+    it 'should convert correctly to and from json' do
+      reload_once = RSpotify::Artist.from_json(@artist.to_json)
+      reload_twice = RSpotify::Artist.from_json(reload_once.to_json)
+      expect(reload_twice.external_urls['spotify']) .to eq      'https://open.spotify.com/artist/7Ln80lUS6He07XvHI8qqHH'
+      expect(reload_twice.followers['total'])       .to be      > 0
+      expect(reload_twice.genres)                   .to be_an   Array
+      expect(reload_twice.href)                     .to eq      'https://api.spotify.com/v1/artists/7Ln80lUS6He07XvHI8qqHH'
+      expect(reload_twice.id)                       .to eq      '7Ln80lUS6He07XvHI8qqHH'
+      expect(reload_twice.images)                   .to include ({'height' => 1333, 'width' => 1000, 'url' => 'https://i.scdn.co/image/fa2e9ca1a27695ae7f8013350d9a53e11d523ece'})
+      expect(reload_twice.name)                     .to eq      'Arctic Monkeys'
+      expect(reload_twice.popularity)               .to be      > 0
+      expect(reload_twice.type)                     .to eq      'artist'
+      expect(reload_twice.uri)                      .to eq      'spotify:artist:7Ln80lUS6He07XvHI8qqHH'
+    end
+
+    it 'should convert blank artists'
+    empty_artist = RSpotify::Artist.new.to_json
+    expect(empty_artist.external_urls)            .to be_nil
+    expect(empty_artist.followers)                .to be_nil
+    expect(empty_artist.genres)                   .to be_nil
+    expect(empty_artist.href)                     .to be_nil
+    expect(empty_artist.id)                       .to be_nil
+    expect(empty_artist.images)                   .to be_nil
+    expect(empty_artist.name)                     .to be_nil
+    expect(empty_artist.popularity)               .to be_nil
+    expect(empty_artist.type)                     .to be_nil
+    expect(empty_artist.uri)                      .to be_nil
   end
 end

--- a/spec/lib/rspotify/artist_spec.rb
+++ b/spec/lib/rspotify/artist_spec.rb
@@ -178,17 +178,9 @@ describe RSpotify::Artist do
       expect(reload_twice.uri)                      .to eq      'spotify:artist:7Ln80lUS6He07XvHI8qqHH'
     end
 
-    it 'should convert blank artists'
-    empty_artist = RSpotify::Artist.new.to_json
-    expect(empty_artist.external_urls)            .to be_nil
-    expect(empty_artist.followers)                .to be_nil
-    expect(empty_artist.genres)                   .to be_nil
-    expect(empty_artist.href)                     .to be_nil
-    expect(empty_artist.id)                       .to be_nil
-    expect(empty_artist.images)                   .to be_nil
-    expect(empty_artist.name)                     .to be_nil
-    expect(empty_artist.popularity)               .to be_nil
-    expect(empty_artist.type)                     .to be_nil
-    expect(empty_artist.uri)                      .to be_nil
+    it 'should convert blank artists' do
+      empty_artist = RSpotify::Artist.new.to_json
+      expect(empty_artist).to eq '{"external_urls":null,"followers":null,"genres":null,"href":null,"id":null,"images":null,"name":null,"popularity":null,"type":null,"uri":null}'
+    end
   end
 end


### PR DESCRIPTION
Added methods for `.to_json` and `.from_json` for Artists.
`.to_json` is a instance method
`.from_json` is a class method

I also added tests to the artist spec.

Apparently my IDE removed all the trailing whitespace from `spec/lib/rspotify/artist_spec.rb` as well.