### PR TITLE
playlist#add_tracks!: remove problematic code, set snapshot_id to nil

### DIFF
--- a/lib/rspotify/playlist.rb
+++ b/lib/rspotify/playlist.rb
@@ -137,13 +137,8 @@ module RSpotify
       response = User.oauth_post(@owner.id, url, {})
       @total += tracks.size
       @tracks_cache = nil
+      @snapshot_id = nil
 
-      if RSpotify::raw_response
-        @snapshot_id = JSON.parse(response)['snapshot_id']
-        return response
-      end
-
-      @snapshot_id = json['snapshot_id']
       tracks
     end
 


### PR DESCRIPTION
*playlist#add_tracks!* threw an error, this fixes it for me. I removed the part handling the raw_respone, because I think it is not relevant here since we're not *getting* data, but sending it. And I set the variable @snapshot_id to nil. I'm not 100% if this is correct but I've seen that in other methods that *send* data.
I tried to write an rspec test case fot this method, but I couldn't get it to run because of this error:
```ruby
Failure/Error: playlist.add_tracks! tracks
    NameError:
        uninitialized class variable @@users_credentials in RSpotify::User
```
If you could point me to the right direction, I'll gladly add a test for that method :-)
Cheers!