### PR TITLE
Added saved_albums methods on User for (undocumented) me/albums endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,11 @@ class UsersController < ApplicationController
     spotify_user.saved_tracks.size #=> 20
     spotify_user.remove_tracks!(tracks)
 
+    albums = RSpotify::Album.search('launeddas')
+    spotify_user.save_albums!(albums)
+    spotify_user.saved_albums.size #=> 10
+    spotify_user.remove_albums!(albums)
+
     # Use Spotify Follow features
     spotify_user.follow(playlist)
     spotify_user.follows?(artists)


### PR DESCRIPTION
I noticed that the Spotify API has library endpoints for albums, and so I added support for them. They're basically identical to the [`me/tracks` library endpoints](https://developer.spotify.com/web-api/library-endpoints/), except you know, for albums: `me/albums`.

One big benefit here is when you save albums to your library via `me/albums` those albums show up in the "Saved Albums Only" filter, which isn't possible when using `me/tracks`.

**The problem is... the album endpoints are undocumented.** I only found them because I was poking around. So I totally understand if this doesn't get merged. Might be against Spotify Terms to use undocumented pieces of their API. Still, figured I'd PR, if only to say hey this exists. And if they ever go public with the album endpoints, we'll be ready...