### PR TITLE
Fix an issue that leads to an SystemStackError: stack level too deep

### DIFF
--- a/lib/rspotify/base.rb
+++ b/lib/rspotify/base.rb
@@ -132,7 +132,7 @@ module RSpotify
     #           track.complete!
     #           track.instance_variable_get("@popularity") #=> 62
     def complete!
-      initialize RSpotify.get("#{type}s/#{@id}")
+      initialize RSpotify.get("#{@type}s/#{@id}")
     end
 
     # Used internally to retrieve an object's instance variable. If instance


### PR DESCRIPTION
Our application has experienced the following issue:

```
SystemStackError: stack level too deep
from lib/rspotify/base.rb:135:in `complete!'
```

While investigating the issue we found that this error was caused with the merge of https://github.com/guilhermesad/rspotify/commit/c5a62ca155e17393c3a038a8dec8f1aeed2ad3ce

The code prior was correctly using the class instance variable with `pluralized_type = "#{@type}s"`.

The new code calls method_missing on the variable `type` in `initialize RSpotify.get("#{type}s/#{@id}")`.

In case `@type` is `nil` the system stack overflows as `complete!` is called from `method_missing`.

We have fixed the issue by monkey patching RSpotify, but I think an stack overflow should also be fixed on ruby gems, hence the pull request.

Best!
Oliver 

