### PR TITLE
adds option to add tracks to a playlist by string URIs, not just Track objects

### DIFF
--- a/lib/rspotify/playlist.rb
+++ b/lib/rspotify/playlist.rb
@@ -115,7 +115,7 @@ module RSpotify
     # Adds one or more tracks to a playlist in user's Spotify account. This method is only available when the
     # current user has granted access to the *playlist-modify-public* and *playlist-modify-private* scopes.
     #
-    # @param tracks [Array<Track>] Tracks to be added. Maximum: 100 per request
+    # @param tracks [Array<Track>]|[Array<String>] Tracks to be added. Either array of Tracks or strings where each string is a valid spotify track uri. Maximum: 100 per request
     # @param position [Integer, NilClass] The position to insert the tracks, a zero-based index. Default: tracks are appended to the playlist
     # @return [Array<Track>] The tracks added
     #
@@ -130,7 +130,12 @@ module RSpotify
     #           playlist.add_tracks!(tracks, position: 20)
     #           playlist.tracks[20].name #=> "Somebody That I Used To Know"
     def add_tracks!(tracks, position: nil)
-      track_uris = tracks.map(&:uri).join(',')
+      track_uris = nil
+      if tracks.first.is_a? String
+        track_uris = tracks.join(',')
+      else
+        track_uris = tracks.map(&:uri).join(',')
+      end
       url = "#{@path}/tracks?uris=#{track_uris}"
       url << "&position=#{position}" if position
 


### PR DESCRIPTION
I have a use case where I store spotify URIs in my database and then would like to add them en-masse into a playlist.
So rather than create `Track` objects for each one, I modified `Playlist#add_tracks!` to take the first parameter as an array of Tracks or strings (and assumes if its a string then its a valid spotify URI)

Is this a change that you'd be interested in?
