### PR TITLE
compact array for following artist response to handle null entries

### DIFF
--- a/lib/rspotify/user.rb
+++ b/lib/rspotify/user.rb
@@ -168,7 +168,7 @@ module RSpotify
 
       response = User.oauth_get(@id, url)
       return response if RSpotify.raw_response
-      response["#{type}s"]['items'].map { |i| type_class.new i }
+      response["#{type}s"]['items'].compact.map { |i| type_class.new i }
     end
 
     # Check if the current user is following one or more artists or other Spotify users. This method


### PR DESCRIPTION
Getting no method errors because the spotify api is sometimes returning null results for the user following endpoint.   I'm not currently seeing this on other endpoints.

bug report here:
https://github.com/spotify/web-api/issues/298
