### PR TITLE
Update rest-client to v2.0

### DIFF
--- a/rspotify.gemspec
+++ b/rspotify.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'omniauth-oauth2', '~> 1.3.1'
-  spec.add_dependency 'rest-client', '~> 1.8'
+  spec.add_dependency 'rest-client', '~> 2.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'fakeweb', '~> 1.3'


### PR DESCRIPTION
Just an update of the `rest-client` gem to use the last version.
Earlier Ruby versions such as 1.8.7, 1.9.2, and 1.9.3 are no longer supported in this version, but the `rspotify` gem requires a Ruby version '>= 2.0.0'