### PR TITLE
Fix a small OAuth bug

### DIFF
--- a/lib/rspotify/connection.rb
+++ b/lib/rspotify/connection.rb
@@ -63,6 +63,7 @@ module RSpotify
       rescue RestClient::Unauthorized
         if @client_token
           authenticate(@client_id, @client_secret)
+          params[-1]['Authorization'] = "Bearer #{@client_token}"
           response = RestClient.send(verb, url, *params)
         end
       end

--- a/lib/rspotify/user.rb
+++ b/lib/rspotify/user.rb
@@ -85,6 +85,8 @@ module RSpotify
         @@users_credentials[@id] = credentials
         @credentials = @@users_credentials[@id]
       end
+
+      raise "Error - User ID cannot be empty." if @id.nil? || @id.empty?
     end
 
     # Creates a playlist in user's Spotify account. This method is only available when the current


### PR DESCRIPTION
Thanks for making rspotify @guilhermesad !

I'm using this library on a side project, and I noticed that there is something weird going on with the OAuth code. Specifically, it is defining the REST verbs once when the module is instantiated, which happens before the `@client_token` is fetched. However, the verb definitions aren't updated later when `@client_token` is present, which causes all the requests to fail. I can't get it to work without this patch.

Similarly, wanted to make sure that a proper error message is communicated when a `User` is instantiated without an `id` (was following the comments here https://github.com/guilhermesad/rspotify#notes ).

I tried to keep my changes as minimally invasive as possible, though I think there's quite a decent amount refactoring that could be done to make the code less reliant on mutable state (it's pretty confusing to read at first glance).

Let me know if you have any questions / comments please!