### PR TITLE
AudioFeature arrays now properly deal with nils

### DIFF
--- a/lib/rspotify/audio_features.rb
+++ b/lib/rspotify/audio_features.rb
@@ -32,7 +32,7 @@ module RSpotify
         response = RSpotify.get(url)
         return response if RSpotify.raw_response
 
-        response['audio_features'].map { |i| AudioFeatures.new i }
+        response['audio_features'].map { |i| i.nil? ? nil : AudioFeatures.new(i) }
       when String
         url = "audio-features/#{ids}"
         response = RSpotify.get(url)


### PR DESCRIPTION
Hi there, and thanks for all of your work on RSpotify! I've made a simple fix for the problem below, hope it helps:

Doing things like 
```ruby
Spotify::AudioFeatures.find(["2UzMpPKPhbcC8RbsmuURAZ", "IAmAnInvalidID"])
```
fails with a `NoMethodError: undefined method '[]' for nil:NilClass` since the `nil` would be sent as-is to `AudioFeatures.new(nil)`, overriding the default argument.  This proves problematic when batch processing dirty data since we would have to confirm every ID is valid before running `find`; simply returning `nil`s, on the other hand, would increase resilience.

Note that this wasn't a problem with single ID lookups because the API would return a HTTP 400 Bad Request exception with message "invalid request" when sending invalid IDs.