### PR TITLE
Adds extra info to options (for ID, etc.)

### DIFF
--- a/lib/rspotify/user.rb
+++ b/lib/rspotify/user.rb
@@ -68,7 +68,9 @@ module RSpotify
 
     def initialize(options = {})
       credentials = options['credentials']
+      extra       = options['extra'].to_h
       options     = options['info'] if options['info']
+      options.merge!(extra['raw_info'].to_h)
 
       @birthdate    ||= options['birthdate']
       @country      ||= options['country']


### PR DESCRIPTION
Hey, thanks for making rspotify!

Noticed that the spotify ID was missing from requests - after some digging, found that it wasn't being returned in `RSpotify::User.new(auth).to_hash` (when creating a user). The format of `auth` seems to have changed - as you can see, it now returns some useful information in `auth['extra']['raw_info']`.

Let me know if there's anything else I can do to get this merged!
