### PR TITLE
Fail with a 401 if the user revoked the application instead of a 400

### DIFF
--- a/lib/rspotify/user.rb
+++ b/lib/rspotify/user.rb
@@ -38,6 +38,8 @@ module RSpotify
       response = RestClient.post(TOKEN_URI, request_body, RSpotify.send(:auth_header))
       response = JSON.parse(response)
       @@users_credentials[user_id]['token'] = response['access_token']
+    rescue RestClient::BadRequest => e
+      raise e if e.response !~ /Refresh token revoked/
     end
     private_class_method :refresh_token
 


### PR DESCRIPTION
This gives the client the ability to ask the user to re-authenticate instead of just receiving an unknown 400 request.