### PR TITLE
Relax rest-client dependency and fix several deprecations

### DIFF
--- a/lib/rspotify/connection.rb
+++ b/lib/rspotify/connection.rb
@@ -55,7 +55,7 @@ module RSpotify
       url = path.start_with?('http') ? path : API_URI + path
 
       url, query = *url.split('?')
-      url = URI::encode(url)
+      url = URI::Parser.new.escape(url)
       url << "?#{query}" if query
 
       begin

--- a/rspotify.gemspec
+++ b/rspotify.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'omniauth-oauth2', '~> 1.3.1'
-  spec.add_dependency 'rest-client', '~> 1.8'
+  spec.add_dependency 'rest-client', '~> 2.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'fakeweb', '~> 1.3'

--- a/rspotify.gemspec
+++ b/rspotify.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'omniauth-oauth2', '~> 1.3.1'
-  spec.add_dependency 'rest-client', '~> 2.0'
+  spec.add_dependency 'rest-client', '>= 1.8'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'fakeweb', '~> 1.3'

--- a/spec/lib/rspotify/album_spec.rb
+++ b/spec/lib/rspotify/album_spec.rb
@@ -11,7 +11,9 @@ describe RSpotify::Album do
 
     it 'should find album with correct attributes' do
       expect(@album.album_type)               .to eq      'album'
-      expect(@album.available_markets)        .to include *%w(AD AT BE BG CA EE ES FR GR MC TW US)
+      %w(AD AT BE BG CA EE ES FR GR MC TW US).each do |country_code|
+        expect(@album.available_markets)      .to include country_code
+      end
       expect(@album.copyrights)               .to include ({'text' => '2013 Domino Recording Co Ltd', 'type' => 'C'})
       expect(@album.external_ids['upc'])      .to eq      '887828031795'
       expect(@album.external_urls['spotify']) .to eq      'https://open.spotify.com/album/5bU1XKYxHhEwukllT20xtk'
@@ -185,4 +187,3 @@ describe RSpotify::Album do
     end
   end
 end
-

--- a/spec/lib/rspotify/audio_features_spec.rb
+++ b/spec/lib/rspotify/audio_features_spec.rb
@@ -23,7 +23,7 @@ describe RSpotify::AudioFeatures do
       expect(audio_features.instrumentalness).to eq 0
       expect(audio_features.key).to              eq 11
       expect(audio_features.liveness).to         eq 0.138
-      expect(audio_features.loudness).to         eq -4.106
+      expect(audio_features.loudness).to         eq(-4.106)
       expect(audio_features.mode).to             eq 1
       expect(audio_features.speechiness).to      eq 0.101
       expect(audio_features.tempo).to            eq 129.972

--- a/spec/lib/rspotify/playlist_spec.rb
+++ b/spec/lib/rspotify/playlist_spec.rb
@@ -57,7 +57,7 @@ describe RSpotify::Playlist do
     it 'should find playlist with correct attributes' do
       expect(playlist.collaborative)            .to eq    false
       expect(playlist.external_urls['spotify']) .to eq    'http://open.spotify.com/user/wizzler/playlist/00wHcTN0zQiun4xri9pmvX'
-      expect(playlist.description)              .to match /Iconic soundtracks featured in some of the greatest movies/
+      expect(playlist.description)              .to match(/Iconic soundtracks featured in some of the greatest movies/)
       expect(playlist.followers['total'])       .to be    > 0
       expect(playlist.href)                     .to eq    'https://api.spotify.com/v1/users/wizzler/playlists/00wHcTN0zQiun4xri9pmvX'
       expect(playlist.id)                       .to eq    '00wHcTN0zQiun4xri9pmvX'

--- a/spec/lib/rspotify/playlist_spec.rb
+++ b/spec/lib/rspotify/playlist_spec.rb
@@ -154,11 +154,11 @@ describe RSpotify::Playlist do
   end
 
   describe 'Playlist#tracks' do
-    use_vcr_cassette 'playlist:tracks:118430647:starred'
+    it 'should fetch more tracks correctly', :vcr do
+      VCR.use_cassette('playlist:tracks:118430647:starred') do
+        @tracks = starred_playlist.tracks(offset: 100, limit: 100)
+      end
 
-    before { @tracks = starred_playlist.tracks(offset: 100, limit: 100) }
-
-    it 'should fetch more tracks correctly' do
       expect(@tracks)           .to be_an Array
       expect(@tracks.size)      .to eq 85
       expect(@tracks.last.name) .to eq 'On The Streets - Kollectiv Turmstrasse Let Freedom Ring Remix'

--- a/spec/lib/rspotify/track_spec.rb
+++ b/spec/lib/rspotify/track_spec.rb
@@ -1,7 +1,7 @@
 describe RSpotify::Track do
-  
+
   describe 'Track::find receiving id as a string' do
-    
+
     before(:each) do
       # Get Arctic Monkeys's "Do I Wanna Know?" track as a testing sample
       @track = VCR.use_cassette('track:find:3jfr0TF6DQcOLat8gGn7E2') do
@@ -10,7 +10,9 @@ describe RSpotify::Track do
     end
 
     it 'should find track with correct attributes' do
-      expect(@track.available_markets)        .to include *%w(AD AT BE BG CA EE ES FR GR MC TW US)
+      %w(AD AT BE BG CA EE ES FR GR MC TW US).each do |country_code|
+        expect(@track.available_markets)      .to include country_code
+      end
       expect(@track.disc_number)              .to eq 1
       expect(@track.duration_ms)              .to eq 272_394
       expect(@track.explicit)                 .to eq false
@@ -45,7 +47,7 @@ describe RSpotify::Track do
   describe 'Track::find receiving array of ids' do
     it 'should find the right tracks' do
       ids = ['4oI9kesyxHUr8fqiLd6uO9']
-      tracks = VCR.use_cassette('track:find:4oI9kesyxHUr8fqiLd6uO9') do 
+      tracks = VCR.use_cassette('track:find:4oI9kesyxHUr8fqiLd6uO9') do
         RSpotify::Track.find(ids)
       end
       expect(tracks)            .to be_an Array
@@ -53,7 +55,7 @@ describe RSpotify::Track do
       expect(tracks.first.name) .to eq 'The Next Day'
 
       ids << '7D8BAYkrR9peCB9XSKCADc'
-      tracks = VCR.use_cassette('track:find:7D8BAYkrR9peCB9XSKCADc') do 
+      tracks = VCR.use_cassette('track:find:7D8BAYkrR9peCB9XSKCADc') do
         RSpotify::Track.find(ids)
       end
       expect(tracks)            .to be_an Array
@@ -65,7 +67,7 @@ describe RSpotify::Track do
 
   describe 'Track::search' do
     it 'should search for the right tracks' do
-      tracks = VCR.use_cassette('track:search:Wanna Know') do 
+      tracks = VCR.use_cassette('track:search:Wanna Know') do
         RSpotify::Track.search('Wanna Know')
       end
       expect(tracks)             .to be_an Array
@@ -76,19 +78,19 @@ describe RSpotify::Track do
     end
 
     it 'should accept additional options' do
-      tracks = VCR.use_cassette('track:search:Wanna Know:limit:10') do 
+      tracks = VCR.use_cassette('track:search:Wanna Know:limit:10') do
         RSpotify::Track.search('Wanna Know', limit: 10)
       end
       expect(tracks.size)        .to eq 10
       expect(tracks.map(&:name)) .to include('Do I Wanna Know?', 'I Wanna Know')
 
-      tracks = VCR.use_cassette('track:search:Wanna Know:offset:10') do 
+      tracks = VCR.use_cassette('track:search:Wanna Know:offset:10') do
         RSpotify::Track.search('Wanna Know', offset: 10)
       end
       expect(tracks.size)        .to eq 20
       expect(tracks.map(&:name)) .to include('They Wanna Know', 'You Wanna Know')
 
-      tracks = VCR.use_cassette('track:search:Wanna Know:limit:10:offset:10') do 
+      tracks = VCR.use_cassette('track:search:Wanna Know:limit:10:offset:10') do
         RSpotify::Track.search('Wanna Know', limit: 10, offset: 10)
       end
       expect(tracks.size)        .to eq 10
@@ -123,7 +125,7 @@ describe RSpotify::Track do
         track.audio_features
       end
 
-      expect(audio_features.acousticness).to     eq 0.186 
+      expect(audio_features.acousticness).to     eq 0.186
       expect(audio_features.analysis_url).to     eq 'http://echonest-analysis.s3.amazonaws.com/TR/TR-mGwgsahAQuIJvg1GFm9sHdVOQa1Tq677JbupMzwMyyKB_i5PBIKWWtTxnarW-qvlA9zRYF6OIY6cnU=/3/full.json?AWSAccessKeyId=AKIAJRDFEY23UEVW42BQ&Expires=1460833574&Signature=5binEjpotRQp8%2BE3LdYipDL%2BE8E%3D'
       expect(audio_features.danceability).to     eq 0.548
       expect(audio_features.duration_ms).to      eq 272394
@@ -131,7 +133,7 @@ describe RSpotify::Track do
       expect(audio_features.instrumentalness).to eq 0.000263
       expect(audio_features.key).to              eq 5
       expect(audio_features.liveness).to         eq 0.217
-      expect(audio_features.loudness).to         eq -7.596
+      expect(audio_features.loudness).to         eq(-7.596)
       expect(audio_features.mode).to             eq 1
       expect(audio_features.speechiness).to      eq 0.0323
       expect(audio_features.tempo).to            eq 85.030

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,4 @@ RSpec.configure do |config|
 
     mocks.verify_partial_doubles = true
   end
-
-  config.extend VCR::RSpec::Macros
 end


### PR DESCRIPTION
Found some version compatibility issues in Rails 5.1 which has a common dependency with `mime-types` and `rest-client`. Relaxing the version here solved it. Specs are green so I assume `rspotify` is fully compatible with `rest-client` 2.

Also, I fixed several deprecations running the specs under `Ruby 2.4`