### PR TITLE
Add option to retry on 429 error

### DIFF
--- a/lib/rspotify/connection.rb
+++ b/lib/rspotify/connection.rb
@@ -10,7 +10,7 @@ module RSpotify
   VERBS         = %w(get post put delete)
 
   class << self
-    attr_accessor :raw_response
+    attr_accessor :raw_response, :retry_on_too_many_requests
 
     # Authenticates access to restricted data. Requires {https://developer.spotify.com/my-applications user credentials}
     #
@@ -65,6 +65,18 @@ module RSpotify
           authenticate(@client_id, @client_secret)
           response = RestClient.send(verb, url, *params)
         end
+      rescue RestClient::TooManyRequests => e
+        sleep_time = if e.response.headers[:retry_after].present?
+                       (e.response.headers[:retry_after]).to_i.seconds + 0.5
+                     else
+                       0.5
+                     end
+        puts "Got 'too many requests error', retrying in #{sleep_time} seconds."
+        if retry_on_too_many_requests
+          sleep(sleep_time)
+          retry
+        end
+        raise RestClient::TooManyRequests
       end
 
       return response if raw_response


### PR DESCRIPTION
Added the possibility to automatically handle 429 HTTP errors and retry after the time indicated in response headers