### PR TITLE
Add market options when fetching tracks from album

### DIFF
--- a/lib/rspotify/album.rb
+++ b/lib/rspotify/album.rb
@@ -104,13 +104,13 @@ module RSpotify
     # @example
     #           album = RSpotify::Album.find('41vPD50kQ7JeamkxQW7Vuy')
     #           album.tracks.first.name #=> "Do I Wanna Know?"
-    def tracks(limit: 50, offset: 0)
+    def tracks(limit: 50, offset: 0, market: 'US')
       last_track = offset + limit - 1
       if @tracks_cache && last_track < 50 && !RSpotify.raw_response
         return @tracks_cache[offset..last_track]
       end
 
-      url = "albums/#{@id}/tracks?limit=#{limit}&offset=#{offset}"
+      url = "albums/#{@id}/tracks?limit=#{limit}&offset=#{offset}&market=#{market}"
       response = RSpotify.get(url)
       json = RSpotify.raw_response ? JSON.parse(response) : response
 


### PR DESCRIPTION
Some of the tracks have `null` value in the `preview_url`. Therefore this should able to pass the `market` when requesting the tracks from an album.