### PR TITLE
Add market parameter and track relinking details

### DIFF
--- a/lib/rspotify.rb
+++ b/lib/rspotify.rb
@@ -7,6 +7,7 @@ module RSpotify
   autoload :AudioFeatures,      'rspotify/audio_features'
   autoload :Base,               'rspotify/base'
   autoload :Category,           'rspotify/category'
+  autoload :TrackLink,          'rspotify/track_link'
   autoload :Playlist,           'rspotify/playlist'
   autoload :Recommendations,    'rspotify/recommendations'
   autoload :RecommendationSeed, 'rspotify/recommendation_seed'

--- a/lib/rspotify/album.rb
+++ b/lib/rspotify/album.rb
@@ -17,6 +17,7 @@ module RSpotify
     # Returns Album object(s) with id(s) provided
     #
     # @param ids [String, Array] Maximum: 20 IDs
+    # @param market [String] Optional. An {http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2 ISO 3166-1 alpha-2 country code}.
     # @return [Album, Array<Album>]
     #
     # @example
@@ -28,8 +29,8 @@ module RSpotify
     #           albums = RSpotify::Album.find(ids)
     #           albums.class       #=> Array
     #           albums.first.class #=> RSpotify::Album
-    def self.find(ids)
-      super(ids, 'album')
+    def self.find(ids, market: nil)
+      super(ids, 'album', market: market)
     end
 
     # Get a list of new album releases featured in Spotify (shown, for example, on a Spotify player’s “Browse” tab).

--- a/lib/rspotify/album.rb
+++ b/lib/rspotify/album.rb
@@ -100,18 +100,20 @@ module RSpotify
     #
     # @param limit  [Integer] Maximum number of tracks to return. Maximum: 50. Default: 50.
     # @param offset [Integer] The index of the first track to return. Use with limit to get the next set of objects. Default: 0.
+    # @param market [String] Optional. An {http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2 ISO 3166-1 alpha-2 country code}. Default: nil.
     # @return [Array<Track>]
     #
     # @example
     #           album = RSpotify::Album.find('41vPD50kQ7JeamkxQW7Vuy')
     #           album.tracks.first.name #=> "Do I Wanna Know?"
-    def tracks(limit: 50, offset: 0)
+    def tracks(limit: 50, offset: 0, market: nil)
       last_track = offset + limit - 1
       if @tracks_cache && last_track < 50 && !RSpotify.raw_response
         return @tracks_cache[offset..last_track]
       end
 
       url = "albums/#{@id}/tracks?limit=#{limit}&offset=#{offset}"
+      url << "&market=#{market}" if market
       response = RSpotify.get(url)
       json = RSpotify.raw_response ? JSON.parse(response) : response
 

--- a/lib/rspotify/base.rb
+++ b/lib/rspotify/base.rb
@@ -11,6 +11,7 @@ module RSpotify
     #
     # @param ids [String, Array]
     # @param type [String]
+    # @param market [String] Optional. An {http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2 ISO 3166-1 alpha-2 country code}.
     # @return [Album, Artist, Track, User, Array<Album>, Array<Artist>, Array<Track>]
     #
     # @example
@@ -22,7 +23,7 @@ module RSpotify
     #           tracks = RSpotify::Base.find(ids, 'track')
     #           tracks.class       #=> Array
     #           tracks.first.class #=> RSpotify::Track
-    def self.find(ids, type)
+    def self.find(ids, type, market: nil)
       case ids
       when Array
         if type == 'user'
@@ -30,16 +31,17 @@ module RSpotify
           return false
         end
         limit = (type == 'album' ? 20 : 50)
-        find_many(ids, type)
+        find_many(ids, type, market: market)
       when String
         id = ids
-        find_one(id, type)
+        find_one(id, type, market: market)
       end
     end
 
-    def self.find_many(ids, type)
+    def self.find_many(ids, type, market: nil)
       type_class = RSpotify.const_get(type.capitalize)
       path = "#{type}s?ids=#{ids.join ','}"
+      path << "&market=#{market}" if market
 
       response = RSpotify.get path
       return response if RSpotify.raw_response
@@ -47,9 +49,10 @@ module RSpotify
     end
     private_class_method :find_many
 
-    def self.find_one(id, type)
+    def self.find_one(id, type, market: nil)
       type_class = RSpotify.const_get(type.capitalize)
       path = "#{type}s/#{id}"
+      path << "?market=#{market}" if market
 
       response = RSpotify.get path
       return response if RSpotify.raw_response

--- a/lib/rspotify/track.rb
+++ b/lib/rspotify/track.rb
@@ -13,6 +13,7 @@ module RSpotify
   # @attr [Integer]       track_number      The number of the track. If an album has several discs, the track number is the number on the specified disc
   # @attr [String]        played_at         The date and time the track was played. Only present when pulled from /recently-played
   # @attr [String]        context_type      The context the track was played from. Only present when pulled from /recently-played
+  # @attr [Boolean]       is_playable       Whether or not the track is playable in the given market. Only present when track relinking is applied by specifying a market when looking up the track
   class Track < Base
 
     # Returns Track object(s) with id(s) provided
@@ -70,6 +71,7 @@ module RSpotify
       @track_number      = options['track_number']
       @played_at         = options['played_at']
       @context_type      = options['context_type']
+      @is_playable       = options['is_playable']
 
       @album = if options['album']
         Album.new options['album']

--- a/lib/rspotify/track.rb
+++ b/lib/rspotify/track.rb
@@ -14,6 +14,7 @@ module RSpotify
   # @attr [String]        played_at         The date and time the track was played. Only present when pulled from /recently-played
   # @attr [String]        context_type      The context the track was played from. Only present when pulled from /recently-played
   # @attr [Boolean]       is_playable       Whether or not the track is playable in the given market. Only present when track relinking is applied by specifying a market when looking up the track
+  # @attr [TrackLink]     linked_from       Details of the requested track. Only present when track relinking is applied and the returned track is different to the one requested because the latter is not available in the given market
   class Track < Base
 
     # Returns Track object(s) with id(s) provided
@@ -79,6 +80,10 @@ module RSpotify
 
       @artists = if options['artists']
         options['artists'].map { |a| Artist.new a }
+      end
+
+      @linked_from = if options['linked_from']
+        TrackLink.new options['linked_from']
       end
 
       super(options)

--- a/lib/rspotify/track.rb
+++ b/lib/rspotify/track.rb
@@ -18,6 +18,7 @@ module RSpotify
     # Returns Track object(s) with id(s) provided
     #
     # @param ids [String, Array] Maximum: 50 IDs
+    # @param market [String] Optional. An {http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2 ISO 3166-1 alpha-2 country code}.
     # @return [Track, Array<Track>]
     #
     # @example
@@ -29,8 +30,8 @@ module RSpotify
     #           tracks = RSpotify::Base.find(ids, 'track')
     #           tracks.class       #=> Array
     #           tracks.first.class #=> RSpotify::Track
-    def self.find(ids)
-      super(ids, 'track')
+    def self.find(ids, market: nil)
+      super(ids, 'track', market: market)
     end
 
     # Returns array of Track objects matching the query, ordered by popularity. It's also possible to find the total number of search results for the query

--- a/lib/rspotify/track_link.rb
+++ b/lib/rspotify/track_link.rb
@@ -1,0 +1,19 @@
+module RSpotify
+
+  # @attr [Hash]   external_urls Known external URLs for this playlist
+  # @attr [String] href          A link to the Web API endpoint
+  # @attr [String] id            The {https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids Spotify ID} for the track
+  # @attr [String] type          The object type: "track"
+  # @attr [String] uri           The {https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids Spotify URI} for the object
+  class TrackLink
+    attr_reader :external_urls, :href, :id, :type, :uri
+
+    def initialize(options = {})
+      @external_urls = options['external_urls']
+      @href          = options['href']
+      @id            = options['id']
+      @type          = options['type']
+      @uri           = options['uri']
+    end
+  end
+end

--- a/spec/lib/rspotify/album_spec.rb
+++ b/spec/lib/rspotify/album_spec.rb
@@ -43,6 +43,17 @@ describe RSpotify::Album do
       expect(tracks.first)       .to be_an RSpotify::Track
       expect(tracks.map(&:name)) .to include('Do I Wanna Know?', 'R U Mine?', 'Arabella', 'Fireside')
     end
+
+    it 'should find an album with tracks available in the given market' do
+      album = VCR.use_cassette('album:find:5bU1XKYxHhEwukllT20xtk:market:ES') do
+        RSpotify::Album.find('5bU1XKYxHhEwukllT20xtk', market: 'ES')
+      end
+
+      tracks = album.tracks
+      expect(album.id)        .to eq '5bU1XKYxHhEwukllT20xtk'
+      expect(tracks.size)     .to eq 12
+      expect(tracks.first.id) .to eq '5FVd6KXrgO9B3JPmC8OPst'
+    end
   end
 
   describe 'Album::find receiving array of ids' do
@@ -63,6 +74,15 @@ describe RSpotify::Album do
       expect(albums.size)       .to eq 2
       expect(albums.first.name) .to eq 'The Next Day Extra'
       expect(albums.last.name)  .to eq 'A Beard Of Stars (Deluxe Edition)'
+    end
+
+    it 'should find albums with tracks available in the given market' do
+      albums = VCR.use_cassette('album:find:2agWNCZl5Ts9W05mij8EPh:market:ES') do
+        RSpotify::Album.find(['2agWNCZl5Ts9W05mij8EPh'], market: 'ES')
+      end
+
+      expect(albums.first.id)              .to eq '2agWNCZl5Ts9W05mij8EPh'
+      expect(albums.first.tracks.first.id) .to eq '1CFz8ZV88CFLwmggjGrW4c'
     end
   end
 

--- a/spec/lib/rspotify/album_spec.rb
+++ b/spec/lib/rspotify/album_spec.rb
@@ -181,7 +181,21 @@ describe RSpotify::Album do
 
       expect(tracks)            .to be_an Array
       expect(tracks.size)       .to eq 19
-      expect(tracks.first.name) .to eq "Acoustic Guitar"
+      expect(tracks.first.name) .to eq 'Acoustic Guitar'
+      expect(tracks.first.id)   .to eq '4l4IytuWNPZaN5EU80TTCO'
+    end
+
+    it "should find tracks available in the given market" do
+      album = VCR.use_cassette('album:find:2js3lkzAjWpD656NK7ZaJX') do
+        RSpotify::Album.find('2js3lkzAjWpD656NK7ZaJX')
+      end
+
+      tracks = VCR.use_cassette('album:find:2js3lkzAjWpD656NK7ZaJX:tracks:market:ES') do
+        album.tracks(offset: 50, limit: 50, market: 'ES')
+      end
+
+      expect(tracks.first.name) .to eq 'Acoustic Guitar'
+      expect(tracks.first.id)   .to eq '0wNeMTVk7bFbDj8YFIq0kY'
     end
   end
 

--- a/spec/lib/rspotify/album_spec.rb
+++ b/spec/lib/rspotify/album_spec.rb
@@ -149,6 +149,22 @@ describe RSpotify::Album do
     end
   end
 
+  describe '#tracks' do
+    it 'should fetch more tracks' do
+      album = VCR.use_cassette('album:find:2js3lkzAjWpD656NK7ZaJX') do
+        RSpotify::Album.find('2js3lkzAjWpD656NK7ZaJX')
+      end
+
+      tracks = VCR.use_cassette('album:find:2js3lkzAjWpD656NK7ZaJX:tracks') do
+        album.tracks(offset: 50, limit: 50)
+      end
+
+      expect(tracks)            .to be_an Array
+      expect(tracks.size)       .to eq 19
+      expect(tracks.first.name) .to eq "Acoustic Guitar"
+    end
+  end
+
   describe '.embed' do
     before(:each) do
       @album = VCR.use_cassette('album:find:5bU1XKYxHhEwukllT20xtk') do

--- a/spec/lib/rspotify/playlist_spec.rb
+++ b/spec/lib/rspotify/playlist_spec.rb
@@ -111,6 +111,14 @@ describe RSpotify::Playlist do
       expect(tracks_is_local[track_id]).to eq false
     end
 
+    it 'should find playlist tracks that are available in the given market' do
+      playlist_in_market = VCR.use_cassette('playlist:find:00wHcTN0zQiun4xri9pmvX:market:ES') do
+        RSpotify::Playlist.find('wizzler', '00wHcTN0zQiun4xri9pmvX', market: 'ES')
+      end
+
+      expect(playlist_in_market.tracks[1].id) .to eq '6roJqzCHo3nZBI1TrbsKhn'
+    end
+
     context 'starred playlist' do
       it "should support starred playlists" do
         expect(starred_playlist.name) .to eq 'Starred'

--- a/spec/lib/rspotify/track_spec.rb
+++ b/spec/lib/rspotify/track_spec.rb
@@ -46,7 +46,17 @@ describe RSpotify::Track do
         RSpotify::Track.find('3jfr0TF6DQcOLat8gGn7E2', market: 'ES')
       end
 
-      expect(track.id).to eq '5FVd6KXrgO9B3JPmC8OPst'
+      expect(track.id)             .to eq '5FVd6KXrgO9B3JPmC8OPst'
+      expect(track.is_playable)    .to be true
+    end
+
+    it 'should find a track which is unavailable in the given market' do
+      track = VCR.use_cassette('track:find:6fi8e1nv4QBqODf9puRcyX:market:ES') do
+        RSpotify::Track.find('6fi8e1nv4QBqODf9puRcyX', market: 'ES')
+      end
+
+      expect(track.id)          .to eq '6fi8e1nv4QBqODf9puRcyX'
+      expect(track.is_playable) .to be false
     end
   end
 

--- a/spec/lib/rspotify/track_spec.rb
+++ b/spec/lib/rspotify/track_spec.rb
@@ -1,7 +1,7 @@
 describe RSpotify::Track do
-  
+
   describe 'Track::find receiving id as a string' do
-    
+
     before(:each) do
       # Get Arctic Monkeys's "Do I Wanna Know?" track as a testing sample
       @track = VCR.use_cassette('track:find:3jfr0TF6DQcOLat8gGn7E2') do
@@ -46,8 +46,13 @@ describe RSpotify::Track do
         RSpotify::Track.find('3jfr0TF6DQcOLat8gGn7E2', market: 'ES')
       end
 
-      expect(track.id)             .to eq '5FVd6KXrgO9B3JPmC8OPst'
-      expect(track.is_playable)    .to be true
+      expect(track.id)                        .to eq '5FVd6KXrgO9B3JPmC8OPst'
+      expect(track.is_playable)               .to be true
+      expect(track.linked_from.id)            .to eq '3jfr0TF6DQcOLat8gGn7E2'
+      expect(track.linked_from.href)          .to eq 'https://api.spotify.com/v1/tracks/3jfr0TF6DQcOLat8gGn7E2'
+      expect(track.linked_from.type)          .to eq 'track'
+      expect(track.linked_from.uri)           .to eq 'spotify:track:3jfr0TF6DQcOLat8gGn7E2'
+      expect(track.linked_from.external_urls) .to eq('spotify' => 'https://open.spotify.com/track/3jfr0TF6DQcOLat8gGn7E2')
     end
 
     it 'should find a track which is unavailable in the given market' do
@@ -63,7 +68,7 @@ describe RSpotify::Track do
   describe 'Track::find receiving array of ids' do
     it 'should find the right tracks' do
       ids = ['4oI9kesyxHUr8fqiLd6uO9']
-      tracks = VCR.use_cassette('track:find:4oI9kesyxHUr8fqiLd6uO9') do 
+      tracks = VCR.use_cassette('track:find:4oI9kesyxHUr8fqiLd6uO9') do
         RSpotify::Track.find(ids)
       end
       expect(tracks)            .to be_an Array
@@ -71,7 +76,7 @@ describe RSpotify::Track do
       expect(tracks.first.name) .to eq 'The Next Day'
 
       ids << '7D8BAYkrR9peCB9XSKCADc'
-      tracks = VCR.use_cassette('track:find:7D8BAYkrR9peCB9XSKCADc') do 
+      tracks = VCR.use_cassette('track:find:7D8BAYkrR9peCB9XSKCADc') do
         RSpotify::Track.find(ids)
       end
       expect(tracks)            .to be_an Array
@@ -85,15 +90,16 @@ describe RSpotify::Track do
       tracks = VCR.use_cassette('track:find:4oI9kesyxHUr8fqiLd6uO9:market:ES') do
         RSpotify::Track.find(ids, market: 'ES')
       end
-      expect(tracks)            .to be_an Array
-      expect(tracks.size)       .to eq 1
-      expect(tracks.first.id)   .to eq '1CFz8ZV88CFLwmggjGrW4c'
+      expect(tracks)                      .to be_an Array
+      expect(tracks.size)                 .to eq 1
+      expect(tracks.first.id)             .to eq '1CFz8ZV88CFLwmggjGrW4c'
+      expect(tracks.first.linked_from.id) .to eq '4oI9kesyxHUr8fqiLd6uO9'
     end
   end
 
   describe 'Track::search' do
     it 'should search for the right tracks' do
-      tracks = VCR.use_cassette('track:search:Wanna Know') do 
+      tracks = VCR.use_cassette('track:search:Wanna Know') do
         RSpotify::Track.search('Wanna Know')
       end
       expect(tracks)             .to be_an Array
@@ -104,19 +110,19 @@ describe RSpotify::Track do
     end
 
     it 'should accept additional options' do
-      tracks = VCR.use_cassette('track:search:Wanna Know:limit:10') do 
+      tracks = VCR.use_cassette('track:search:Wanna Know:limit:10') do
         RSpotify::Track.search('Wanna Know', limit: 10)
       end
       expect(tracks.size)        .to eq 10
       expect(tracks.map(&:name)) .to include('Do I Wanna Know?', 'I Wanna Know')
 
-      tracks = VCR.use_cassette('track:search:Wanna Know:offset:10') do 
+      tracks = VCR.use_cassette('track:search:Wanna Know:offset:10') do
         RSpotify::Track.search('Wanna Know', offset: 10)
       end
       expect(tracks.size)        .to eq 20
       expect(tracks.map(&:name)) .to include('Wanna Know')
 
-      tracks = VCR.use_cassette('track:search:Wanna Know:limit:10:offset:10') do 
+      tracks = VCR.use_cassette('track:search:Wanna Know:limit:10:offset:10') do
         RSpotify::Track.search('Wanna Know', limit: 10, offset: 10)
       end
       expect(tracks.size)        .to eq 10
@@ -151,7 +157,7 @@ describe RSpotify::Track do
         track.audio_features
       end
 
-      expect(audio_features.acousticness).to     eq 0.186 
+      expect(audio_features.acousticness).to     eq 0.186
       expect(audio_features.analysis_url).to     eq 'https://api.spotify.com/v1/audio-analysis/3jfr0TF6DQcOLat8gGn7E2'
       expect(audio_features.danceability).to     eq 0.548
       expect(audio_features.duration_ms).to      eq 272394

--- a/spec/lib/rspotify/track_spec.rb
+++ b/spec/lib/rspotify/track_spec.rb
@@ -40,6 +40,14 @@ describe RSpotify::Track do
       expect(artists.first)       .to be_an RSpotify::Artist
       expect(artists.map(&:name)) .to include('Arctic Monkeys')
     end
+
+    it 'should find a track available in the given market' do
+      track = VCR.use_cassette('track:find:3jfr0TF6DQcOLat8gGn7E2:market:ES') do
+        RSpotify::Track.find('3jfr0TF6DQcOLat8gGn7E2', market: 'ES')
+      end
+
+      expect(track.id).to eq '5FVd6KXrgO9B3JPmC8OPst'
+    end
   end
 
   describe 'Track::find receiving array of ids' do
@@ -60,6 +68,16 @@ describe RSpotify::Track do
       expect(tracks.size)       .to eq 2
       expect(tracks.first.name) .to eq 'The Next Day'
       expect(tracks.last.name)  .to eq 'Sunday'
+    end
+
+    it 'should find tracks available in the given market' do
+      ids = ['4oI9kesyxHUr8fqiLd6uO9']
+      tracks = VCR.use_cassette('track:find:4oI9kesyxHUr8fqiLd6uO9:market:ES') do
+        RSpotify::Track.find(ids, market: 'ES')
+      end
+      expect(tracks)            .to be_an Array
+      expect(tracks.size)       .to eq 1
+      expect(tracks.first.id)   .to eq '1CFz8ZV88CFLwmggjGrW4c'
     end
   end
 

--- a/spec/vcr_cassettes/album_find_2agWNCZl5Ts9W05mij8EPh_market_ES.yml
+++ b/spec/vcr_cassettes/album_find_2agWNCZl5Ts9W05mij8EPh_market_ES.yml
@@ -1,0 +1,145 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.spotify.com/v1/albums?ids=2agWNCZl5Ts9W05mij8EPh&market=ES
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      accept:
+      - "*/*; q=0.5, application/xml"
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - Bearer BQA0P-TuSn2tg__j7GK4WEjMYUp_fS4F3NdPPGjXkKS4Alhv-ywIaEEVBvpPlX7rKHkZyVtRSYObRpTb1sz9CQ
+      user-agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - nginx
+      date:
+      - Thu, 28 Sep 2017 10:05:18 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      keep-alive:
+      - timeout=600
+      cache-control:
+      - public, max-age=7200
+      access-control-allow-origin:
+      - "*"
+      access-control-allow-methods:
+      - GET, POST, OPTIONS, PUT, DELETE
+      access-control-allow-credentials:
+      - 'true'
+      access-control-max-age:
+      - '604800'
+      access-control-allow-headers:
+      - Accept, Authorization, Origin, Content-Type
+      content-encoding:
+      - gzip
+      x-content-type-options:
+      - nosniff
+      strict-transport-security:
+      - max-age=31536000;
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAOydbVPiyBbH3++nSM2Lu7tVu9d+Sj9M1daWICqKoqDicOvW
+        VCfdLcGQYBIEvLXf/QZ0ZnQIEAnFOBbzaiY5/JPunPPLyemH+d8vlvVB+s6g
+        F3+wPlr/sf6XHvhy6HMy7uvJ4cd/fvjj6VyUeHHywj49qkeJjgLpfx5E/vTc
+        lzPpubgfJp4ZT6U6SdKPP+7shH0d/PvpxL/dsLfzKLsDwubByLSaQVC/7uwh
+        czx4QAfjD09i//zx5XqdSJsXgrLvvdC7h0+S8TzNr1qemiotMwtk77E79uS9
+        p6xSOPT0t7PfOmt61W8nBpE3Pf50cx8fz39c1NB/rP8+dbYb9seRd9OZ6e8k
+        7fCp7G9nv1sIQGxVm3Wrod0wUvEf1iBQOrL0yPUHsXevLd9zdRBrKwmtcugP
+        eo4nvxlLa8+792IvDKzQWM0wGFsn6c9cqxKkDzWRXtDTQZLR1LPvb/erF3jq
+        hRN8GPTd6S84p4QQZAtE+NOPv//p9w6U030mLrqD5E3rtNz27YtYtIDd87q8
+        ctZ5eaEbHUT6qTu/3Hcub5qGybxLPAk9udISo5680d8/0I6ePObJQUrAM+fx
+        X9xXeleuCtJb2pmK7HBXKBcLqRwBgdYSUKjTPwQrqJV0gevamrsGfXt4Q08l
+        nafLPPVL1k1gkP8miISQQqEIl1QAKYhxDMHAYIEgJlBjDQAFxGTcRHqZBTdB
+        Se570Cy9DpSAa6hsYRRiWBOhtGZaICU4kA7mmLLMjvjOi33p6MerfYmVL0/u
+        KwIuOto6TV3W2pNjqzJKoq8m/bA/8GXkJVOHRU9HI+1rGevPSiaPApOQ/RPC
+        PwH8kGHyuR9pdxqRU2Mlv2DoQ3ol9/ZlfBR23p1H0b9DY2Kd/AX+5Xs9L/nL
+        Bv/qyeg2PVJpPoNlonvf+e68l8LiuH5VdOd5OTwL8tf0TL6XxPPozmO68GXx
+        +CTnvDCe3P3VL40XPjwVUV7sfg5SB9bRRAw+PzWIZJK61+fHZ4kAZZw+O69H
+        /fSV4U2j0Eg/1i/OLXii+Z7n1OF2YHn/gbevOC/v14a9m5vuQdQi7rPWPLto
+        nkf56MbzZJ+JPT3HHIbx574vx9Lxp48qiQbPO8L3glutPpso7M10w1rc/rGb
+        SFgVtzoejw4vI27uvJqig7oo5vVPXTVHOsvp85h+demp/GKPnpp8XNa25y6Q
+        Cd/nTyuF5r2nh5+/f1f0v74ren3855PVDgeTVydyCRMEAkKlcbgDlGQUMYMk
+        VgYyGxL6t+upv2zpQldJJBW2idRSQqkQFVhh7DiCv3CaacvmxN3cHprTP4tD
+        5Nlbc8vgn53BkHHCwaYZTJyzU6DJyfVladyrx7Xo7ii+vyzM4DmyswzOYfgW
+        GEyv3Hp5NKp2+qf7Z2Vuk9vx7iVbC4PnSGc5fR7T1zN4WdsyGbznRck4Dalx
+        vDqBleFUUQ5co4gyDiGOQ5kGxJGOcSBKPxm0rbhkhQmMChB4cYBsCfyOCIww
+        gxhvmsC4WqrzIwJMqYwDeNzip50r2S9M4DmyswTOYfgWCEz2wzOxW7volQNY
+        H57f1U4OB+O99WTB2dKZWXAO0xWy4CVtm5sFNxMZxdZvu5G26oPEugiDSenk
+        99WRbDhIM1/HRtx2tAACYwUcx2AEDVBa2AAZ2witCyMZF0Dy4ojZIvl9IZmC
+        jSfF1EWn/FOjcddN9P2BqR6F99cHZ4WRPEd2Fsk5DN8Ckhm7bJfp5YHqPvRg
+        fHZ8cuP5wl8LkudIZzl9HtPXI3lZ2zKRXAvvtVWNrVr4ImxeyWCHGmCMcIXN
+        IdaCpEymjgCcI62Ma2PMHGKM6xRmMCnA4MUhsmXwe2IwmYzjbJzBB9He0YDd
+        8avdkXOsLv1PD/rhojiDs2UzGLzc8C0wmLp8//hO+ru3lA3ORWCaZRDy9RQm
+        sqUzCxM5TFcoTCxpWyaDWx2dZsOTjLilrdNw+PfqIHZtBrhIiauREMAxQkEH
+        KWI7hGtCZJopI0KRgYVBbBcB8cI42YL4HYEYcoTExkHMKt0LMjiIOrdnSXwK
+        VHSoBzEsDOI5srMgzmH4JkB82+mp/X33SB5Ur+6OkkO639yvrQfE2dKZIM5h
+        ugKIl7QtE8RX0tdB4gX617jYQB0DBEugCOUOU7bkmCubqTQp1pgyKeikHiFs
+        UBzDtACGF0fJFsPvCcMC4c1PliDg5KAXnwZdrzPcG/ilftK5wcfFB+qyZTMG
+        6pYbvgUMo+R6TKql2vXgJO6U0H651rlsX6wFw3Oks5w+j+nrMbysbZkYrhrr
+        UziwyjKwmlpbJ3p1ECPb5hxKB2Bma5tpSg0W2kXMaC4NMwgKW9kGFwYxKzJe
+        tzBOtiB+RyBGiAi68eIwGEKMxuNhcjXqVxqViwfVK7eTwiCeIzsL4hyGbwHE
+        5LjD41rbrbj79XhEmS+GsWOvZ7wuWzpzvC6H6QrjdUvalg3iX5XVkElHR1ZJ
+        W4feTWd1EhvhGEkNNdwljgMcGyoDJUWOYZNZFNIWRgDCSWES8wIkXhwoWxK/
+        JxITwTY/cwK47fYY+WK3DyPUbdzYlTNYuy9O4mzZDBIvN3wLJKZnN2f3rc4u
+        hpWDIb4/2m0eHlRv11OZyJbOrEzkMF2hMrGkbZkkLoVxbNVNoVyYQ9sRjrKJ
+        SxTUrgCOy2zGJVQaSMKI6xrkMqf47GFRhMALA2RL4PdEYAAZ2XhRAtHzshqA
+        Uun+DpW9/dNmq1mCYWECz5GdJXAOw7dAYDRqXt18UrXuLqi33arPQ5xcResp
+        SmRLZxYlcpiuUJRY0rbs2cMycL3gZjpprRpYzb50C7DYBbbA3NET7CI6mUzM
+        NXUIA9pxMWU2Z9BABXjxlRygAIwXx8oWxu8JxulX2OZnTOAWqJqzrvMwGFSG
+        tEzI6Tis0uITibNlZ2Gcw/AtwJjc8r2ufXJ6IXaDexIfjlizxNazlGOOdGZh
+        IofpCoWJJW3LhPFhOLT2Qh1bkxnFB5FMk+ODqNDECZbSVipHupQRB0DKeJos
+        Y+hQyYAN009FpW1bK1AcyEXW1i2Oly2Q3xOQIUKbX1sH4uuG5knJYxe73L1u
+        XY6CEjkpXp/Ils2oTyw3fAtApt0uOGwDu3wwkkN1QY936wf1T+upT2RLZ9Yn
+        cpiuUJ9Y0rZMIP82GbBreb7/u9XUyRTLrTDylVUPrH0vKpApG1elEFZQOlJy
+        zNL8mGIjJeHIIZBCBCkSjsJucTAXWXK3OG62YH5PYGaMgY2XLXAbN71uuZXI
+        TqnlwObpcQO015ApZ8tmZMrLDd8CmNGwh3Sl650k93hoSL3ihJqtZ0rbHOnM
+        skUO0xXKFkvalgnmCZf3tfatZmjVwkD748e5FeEghfOeVwDMEiAsKYeu7Rib
+        ERs6NqHQYVC6GnBqOCYYS72GjLnQwruFcbMF83sCM7WRvfESBuz2g/YNqFaq
+        gt6UQeMiLrUejorvCJQtOwvmHIZvAczgonKlDjDdq101z+lulQLTYAW9/svH
+        RbZ0ptPnMH09mJe1LbuEoWWBBXdacQC1xNx1MVQUaWaURsiAlMLKMKHTv2DF
+        VHH4Fllxtzg2tvB9T/BNE4DNzzBmPVKq6vbhiVsat9A1re0n+vqh+EKPbNlZ
+        +OYwfAvwZVR2zy/iW9ck/oFoYzQ8bDXkelY9Z0tnOX0e0xVWPS9pWyZ8d5Ow
+        57lydf4qCSSlk2XPEroSYEcyBzoukBxNtmjTGBluM2T/0J3YFkfHFr/vCL8U
+        UfADhu/6JVqpXUKKGqKJb73TTzdO0i5elMiWzShKLDd8C/ilx0ctrm8G582o
+        cndS4SwS5XZzPdXibOnManEO0xWqxUvatnTTCetP61D7fmg1E50ebWjP7Vgn
+        3shyxtZR+oPYOhlE/c7YMmFkJR1t7e3vrs5tAY2AwtaObYBjFLKJocg2zAgu
+        AQCYKMEgofKH7t+2OKy23P7ZuI3mcxsigNnmuT26NKUabnUb3nAwMlFH44FA
+        xbmdLZvB7eWGL7n9fU98fchnvgwW0CAY+P6zs5GOk8hzJ/0/23+RlvHT5uWP
+        e4hn98dadwVb+By2gf6zBfrCUSMINz9qRKmCvf1Kp03OB7xeuqu4dqODi+9I
+        ky07G+g5DN9CgoZ7R67X69+f+d29fpXFXi84FGYtCdoc6Synz2P6+gRtWdvm
+        btRYDdKMq6ejAskWolwRpAyTihooGHIhdgylwBUYCsd2CIBQFl9wUITBi0Nk
+        y+D3xGAkfsAAERq1xuX9u0aJKjZqJ01THXzqFd8VbI7sLINzGL4FBkM/cfZq
+        w9JNw2nWSyeNO9q8G69ngGiOdJbT5zF9PYOXtS3n4tv0U/lKBzrxZDD5Qi6w
+        EkwawqAxxnGFVk76SQxtV1FqI5cKRrgNOGGEoh+6XePiuNmC+T2BGQi8+V0R
+        6JHXqarkvBYdYvApvibHUO0W38V8jmxGcrzc8E2AeVwv8eb1IRzSGjxpYgfF
+        o6PGesCcLZ0J5hymK4B5Sduyq5ferbak1QjdW51YJwsLEMsmtwIXaQSMmGzK
+        SIyBWorJUJLBBFDkUISgtLUoDuJC2zUujJMtiN8RiCfbNZKNg9hmVycYR2MN
+        jnvnLVkew6NyufiigzmysyDOYfgWQGwHOj66kyf1iPgPyfnwSDaP7tazb+4c
+        6Synz2P6ehAva9ucTRGiYLIWV1qX+/UCa3ERpZwTLYSxU6YK7DDDmcuwsZVR
+        EjgQUA3t4jvTFNmscXGMbCH8s0F40ZgQBXjz+yKA4Or0Kjls7F1eHV+Kcbd/
+        1x7d3hRf+ZUtOwvhHIY5x4Sqv/q+dSHTJG0y0/1isrn2jx0iKrQj1cLHso37
+        ny3uF30F2/AHjAXDy7PR4W73frf1ibWvovH+Ya9D52yG8ZpPu2zZ2bjPYfgW
+        ki8sruBdJ7aPTu4Sj8MrVhfnSW89Q0TZ0plDRDlMVxgiWtK2zOTrIEwDytdx
+        PJ2Uc+BF/uoZmK1d5NqKaA2loUYzZROH2Bo5BjlEM4gIBxoV/18Vi+zSujhQ
+        tiT+2Ui8KAOzAd/8f+GFVVT2L+7I/dFQtY7U8JIFqjqnGPUavGTLzpI4h2HO
+        DKwZWs3OD066Cm18tPhRPHOr9PXTe3QL++v1PgSpS3zfyg+hMbGeHv5mOO2V
+        cBDPGCdhIqcdhcgvzxr6LEh8Z/CF+7PRMTn5Ecmb1mm57dsXsWgBu+d1eeWs
+        M2lDev+//PN/AAAA//8DANVuwcZIhwAA
+    http_version: '1.1'
+  recorded_at: Thu, 28 Sep 2017 10:05:18 GMT
+recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/album_find_2js3lkzAjWpD656NK7ZaJX.yml
+++ b/spec/vcr_cassettes/album_find_2js3lkzAjWpD656NK7ZaJX.yml
@@ -1,0 +1,185 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.spotify.com/v1/albums/2js3lkzAjWpD656NK7ZaJX
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      accept:
+      - "*/*; q=0.5, application/xml"
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - Bearer BQA0P-TuSn2tg__j7GK4WEjMYUp_fS4F3NdPPGjXkKS4Alhv-ywIaEEVBvpPlX7rKHkZyVtRSYObRpTb1sz9CQ
+      user-agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - nginx
+      date:
+      - Thu, 28 Sep 2017 10:31:56 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      keep-alive:
+      - timeout=600
+      cache-control:
+      - public, max-age=7200
+      access-control-allow-origin:
+      - "*"
+      access-control-allow-methods:
+      - GET, POST, OPTIONS, PUT, DELETE
+      access-control-allow-credentials:
+      - 'true'
+      access-control-max-age:
+      - '604800'
+      access-control-allow-headers:
+      - Accept, Authorization, Origin, Content-Type
+      content-encoding:
+      - gzip
+      x-content-type-options:
+      - nosniff
+      strict-transport-security:
+      - max-age=31536000;
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAOydW3PiyJKA3+dXKPrhzG5Ez3TdLxMxccLgu/H9gu2NjY66
+        ggxIWAhsfOL895XAg90GQx+JYPZBL7Jbyk6BMv0psyor61+/BMEX1dXD3vd0
+        3Hdfgj9e//nl6+RKkoaDdJCf/p/gX9mZ7Jx7Tl0Sqe73YdKdXJmez64M+nEa
+        +vFESTtN+4M/vn2L+y76/fXC7ybufZuq/MYumg9X548HjQZXMD0HN6o/bhx9
+        maj699fpndqJ8z8oU/3wB10j+Kpu8Jm+V02hnehZLhSp3vQBXLVdcKxakUtD
+        E+yGrmsHf8m8PaTJff86PUzCydnXD/fH9Oofn3/Jfwf/O33AIxV2le667z2V
+        dNxfj/rL1sWXr8GX2unkOPm9vjU5NibHyfn65Pz25Peden7cu8qP+yf58fg2
+        P54c5Mezyf8925kc7/Lj5U1+vL6cHO++vH4aE/fHSdhqf7B4mpl88vWglDI4
+        dknLBRfOxMmC51KffLuvRf7r2fsHM/Oy0L5zsi/DvpnIAswgR5IwieD0jr98
+        7po/6Zi5239DDwPc7bxsPTT724yykyN+rw5v327RclHiXh/P9JP+lJfmugef
+        KZ+oeXXRpSI91XI/mqbtcnPlpxgBM2fs/vB5sk9jbJR9lG8TBd8AshQohiQT
+        lFDvkYEEQS+5opQDrYA2knPp/zLQU2jT9ustfjDu280x+NmbC2QNNhBIjSSn
+        VHsrLYQAQOANwlgYaqiSQMzdPLvFJzdn5Ge/OFeCAGwxwJAw4RnRRCHiJNfU
+        O86BY8YLO39vRt55Zvbn6qb3mXfnN4YwGTTikQsu46j1eq0f94ddlYTpxBEp
+        nZxMXNepgftuVepmfyi/AfkbJF/mBL73E2fCQRhHE1GrxlOZNFGm897hS/vk
+        t6nKf8beD1z6J/hHN+yF6Z8UzIiaut4Prrj4bbH8jbHWt8a7N8d63x4//Qb5
+        2bfIkjdJsbfJ5KtP3XNqiP9Pb5XJJ7LhwHyPhj3tkvyzwLcLw0SlmUN/n3qT
+        JJyw2UX33O+GJpz8lXvVHbh3Vz51qZ9zqIl/f4PibCu9PjzCKYHyVPq0c33/
+        fDJ7pLPb/YwvTf9iPlM5U/XqSKvEZm60pQdxd5i67jioD00njt9kMhqMQvf0
+        /SP3+jPu9fr4t1epb5Q7Kz0GHFOhOCBcEQit8di57E3KiaNMOgjsP01o/6TK
+        QGMVUhZTopxSUFnEZMZOrLUU5u1DTL72QtPOPHwi8vY/Prr35PIfy0wxo34F
+        mQoy5SGDKCMUb44yiLQvndiNWk9PN9FueCxeWmenvBRlPlH5kTKrxGZ+dBBs
+        x9GvaVBz3dBlYUsYBWnmWpfDqChupBQEZRjJIOIkBEJIxgEABDtMoIWSM+ZN
+        FvqVxA0qiJtlNqlwU+FmjbiBjEG8QdyAg1HtkMO9xtl+fbh7KtsXunm/VQo3
+        n6j8iJtVYm9BTbcbHI+DRpimXRc03w0H/Oec0RxZnqWmmjqeoYNIBhDjzBPq
+        mGYAMqe58b4kZ3BBziwzRsWZijNr5QzkYIPJE90dX1ulCRy2/aF+GLnR7UHj
+        sRRnPlH5kTOrxN44E9Tboem4KGiGaTs4SAfBvlM2y6TS4NT7osyBgDgnPdCe
+        CAkp8YozzhGwggDGbXYVU0lcWeaQgsxZZpiKORVz1sgcRpHcYGgDb5ijnav0
+        HnVrrndytdW+6bVcufGaxSrnxmtWiM3c6MJFcbCtOnGqiuJFWGl9FjRqqSX1
+        2hBHAFUMKK+cBsIL7RUQpOxIDS06UrPECBVeKrysM6QhiP01tbSR1Ene+YPG
+        Pj6/42en57pdM3z7ZFQudVqsci51WiE2N1LTVFEapHGw57JQZuSS4C4eFgWO
+        QxhChy0VQDOChdMIEcAxydIogQ2nDhguJC4JHFYQOMusUgGnAs5acygB2AZz
+        KNDA9mKLjm7ubq/22w16v8X27k/LAWexyjngrBCb+VE97rmglqkOdpO4F1yq
+        KPtFRSZ7ooXnoiQVCHOoGNfeUMqoyHKoHB/ZCced9hBqoCgpCRxeFDhLrFIB
+        pwLOOueiEMabHBxG/YZ8TsjxS+S9lNyRBxPHg3JzUYtVzs1FrRD7wY8aQ9MJ
+        3SAN9objIJ5ORjXipyzM2VHZ2cvQusLZFVIouz9CHGKTz0kJTpCwJmOPQ1mo
+        Q41hiFtdkj2i6MTUEgNV7KnYs9bsiuJNDhiznYtnebh9NGiB8Olo567Gri/k
+        bSn2fKLyI3tWic38qOHSXwfBWeJSF9mg6X5NsthnGEXj4EJpHaaFp6kMlpR6
+        Tz2QGmLmLHSSeEeUtIBkgZB3HlpWOsWSBamzzDQVdSrqrJE6HCK4wYAHx2mj
+        82zCm4vo+iCEzUFtu886paDzicqP0Fkl9oMb1ZVJh4Og2XYZce7iYZJPVCVZ
+        pNOOh10b1AqHO5Lm01EAaaizWIco4gx1CAksCNeEIWe9zQR42bI/UJA8y+xT
+        kacizzrjHYr4RgtxWvxJnQ+MaDafTXt3a99ftHfTcoM7i1XODe6sEHs3mnzV
+        DqNOcBCcOGcDlf14mpKncKAjiRQYcC0kMl5y7YTCyEvhkXEWywwrHnJQmjdF
+        64yXGaXiTcWbtQ4mI7LJUIdd7/XNrdk5UdeP50dnhsWPp46Uy68Wq5zLr1aI
+        /eBHtTjuBLGfrI8qShkAgdYYYeEgE9BbZZAlUPvsh8ZWirzyWBOKylKmaHnx
+        MlNUlKkos9aoJnupbnAUh/d7pw+o52u9Rxzt9/cPRmfR1UEpynyi8iNlVonN
+        /Gg3tPHXaRbVcGrQDg4GwVUcZ8SJWkWJo6B0jhCDtaGSQ+eoVNYTbhQRylCj
+        ERfYOlaWOEULjZeZpSJORZw1EocKjjZYlINb4ojfxk+Xe6x2q/dutzuItONy
+        IziLVc6N4KwQm7nRfvwU7OZTVlEruIh7KsrcqShoMMecaWMM15phzQTFykhA
+        rKZSOiQVgJJQC8qCpmh18TJzVKCpQLPO0IbjjZYX0+vWWGBsO87c3j3fivrR
+        nkrKkeYTlR9Js0rsBz86jSZDxMGFU93uuFQehUUGF6WNREgjTRg20FkqEdTY
+        UWs1BIyRzAhlYVO01niZRSrYVLBZa1QDxAajGt7hfXcZ3+mX+7uH66Ha67LG
+        2JZLoxarnEujVojN3OhsGHXKjdI4zCGmgnGnucZGSyCxIpxDBQ3Ne1Fkj9wI
+        WpYuRQuLl9mgoktFl7WGMoyyDeKF9GujgeSjbmtnP6719DHcr29dlcLLJyo/
+        4mWV2BteVKKsGwR7cVAbF0UMZ0YTBzKWMKSBcoITl6HGWkK8N4pqIqiTrDRi
+        ipYSL7NDhZgKMesdltlsmwly3LjqHdTvBjqCvna5fX8qwpJtJhaqnJvdXiE2
+        c6NarIJ6HA3SJDRpnBSe0lYYO8EgoM4STw2lUuh8dMZKxanhCuiM7rxsxTAs
+        WjK8zBIVYyrGrDOMgdl7dpMlwzh8YeD6oT6Mxvs79uRyjyS9nXJT2otVzk1p
+        rxB712MiLxdOx8FemHTzmaZG2Ck+HsOx4hZQoI03iHgCmc7XfgupPTAWc+sR
+        5OWr9QrXCS+xR4WaCjXrRI3gG137zY8a5y/j4+ft0VX38eDKPw9D7PbKDcgs
+        Vjk3ILNCbOZHx+Pg0kVp2MsOqhscu25sC2dOMO9fQ9mkBJgKRjHBBBAOmWJe
+        EAmxc0BiUraJDSpaGLzMHhVqKtSsEzUke6Vuso3NYB/Uwm7tQrTc/tYejM5b
+        o7NyizA/UfkRNavEZn50EqftfDb7WKXZV54sTIhe10Nt54u/ixfSIAsxII56
+        ZRzmAijNjEbaaiQRRFZio7XCqjR3CjciXmKcijsVd9bIHSQl3mQlDTu9bO3G
+        L32CEnKY3A/SZth4KNc+6xOVc9nUCrGZH10+OZf+1ohHYfRr5lCF2w8Lx51D
+        DEhLLAbesxwpAFFlfRbeAKwls4bysh0mUOEC4SWmqChTUWad0Q2GeJMFwvhO
+        k/ooFh19GGJVq7XDrV17Xa5eb7HKj5RZJfaDH+ULn1pZYJMFNKENVGTzn3ln
+        re3CbW0EsQAwbIFwCCtNZfbTE2gUtcZAopTj2GBUuud50RrhZZapoFNB5z+H
+        DvoMOiiL7Dc5eFO/Dw867UH7Vuw/dtqtg/vzowtVbvBmscq5wZsVYm+NQeOB
+        K9w+ggttKCBMAqk8c5xl4PA6bx2BGLVSoww7SnrzN23esuzxV2CpwLJGsMC8
+        1fYm+0eMdy86eOAvDDHtrTPfAo9Pol0umlmsci6aWSH21rQm32judeIpOFQv
+        L0Up4zxwBigAJLJAKwa8hsqRLJAh+YS3s5JoXr5JTdGcaZkpKspUlFknZahA
+        m5znRkd4tzm86Nzyh8b9zdPxUb1/ft0o15ZvscqPlFklNvOjyQjw8TioxeOg
+        qbqdQZYoPb1uE5UmzhXuGEExhgY55/J5J2YAs8JTSxEm1nIlvCckX+1ddsFT
+        0aRpmWkq6lTUWSd1EN5o1oR8DB9oRyc3zYboP9Qf+SM63C5HncUq56izQuzN
+        j8KeC3aieNhqBz5Ogot4usry3XzUadcWDng49wAjhqxR1BBrXN6PDxKNoSfS
+        ISedA0iWrR4uutRymX0q9FToWSN6BBObXP0EonO83zjrHjRGYzbeHTyEV1Gj
+        3OqnT1R+JM8qsZkb3bhkHOzmvT8L0yVLmiTzVkGjCROQGO2wFVATT7hjWbjj
+        DSHq79rHZZkNKrpUdFlnYEME2eRCbjLoCtF/vo/3D58g3VOnD6dprdygzScq
+        P+JlldjMj/aSfMqprqJxXHiSmyikNbRAEW+FynsJK08NIlJK47nBGjMJNCrb
+        Bavo8splVqgAUwFmnYCRhGwyfoE82q09N+j97snFMbuJzrQbPd+Uq+BbrPIj
+        YFaJvavgmzSKaIbdbrCTbxA1GSYus0sUQVAJw7OIBkFIsUfZQ2ccKs88xdAx
+        qG0W1JSlTdGVlstMUtGmos06aSOY3Gi98Na9HGFBR4OH+wif9PfD4f3tUzna
+        LFY5R5sVYm+NhP2kJc10b7p6UjhnIggBrgg0AigJMmIYSQ01nArqGQVWak49
+        IWXr9ooutVxmiQoyFWTWCRnMN7qem1s4VOCUsW7vETePTfNpuL/jy5XQLFb5
+        ETKrxGZ+lBEmH/A9HmeRTXcc7Me9wgstFbUcU2YoIlQSCqAARHPpvTNCmnyu
+        O1+F6cuuQii6znKZMSrOVJxZK2eE2OSWl7C1fXZ99WwehY8ueecBDG+luiwX
+        zCxWORfMrBCb+dF/1RP1Mp7MN+VBTW2Y/ndwEqfBVVvlwU12rXB4Y5DkRkOs
+        EIAaQi0ymGgnsvxVcG8lp0Q6iMsOCRfejWWZcSruVNxZ62Q3BJsssQGN5K5v
+        mYtOd2375nSHx2l6f15yq92FKuemnFaIvV/fPQlsdpPQRYUntaXEhBkJkfQC
+        OYWNREooDDLoKAWMk5JRqkHZFKr4DixLDFExpmLMGhmDEIMb3V33JfZnreYh
+        jHYv9Lk9Gvja/dNhuYKaxSo/MmaV2FvXvSTuhQM3yHdg2cm/dJgWjmaogdIo
+        6bjDTiKHjCFWIskchR4SzDX3BAFftl648C4sy8xRkaYizVqHhDnZaOlejV+j
+        U9ulVFyo+Ppup31zEpXrvveJyjnSrBB7KxiOk64t1T+YEKItRxp6Cg1GmlHE
+        AALKUSe40xB56LClZQdpCu+5sswIFV8qvqyTLxDDjS57OlfiFtq6uGoNyHm6
+        F+veqF5yEfdilR/5skrsjS9qkC/hTuPoa7D9e/33opSxkmFKM2II6YlG2sl8
+        0YEWNItgOOXECigMF6XzpcIbriwxRUWZijLrzJcgB5us0+ON3afR+OJkFFLV
+        r49jeaus2C8357RY5dyc0wqxd4sro9Zvu3HSitPURcGuCpNxqrqFYxqOuWeY
+        aaOV4QYTIoWABklM8425iaHSWQJp6YblRauCl5mkok1Fm7WOAAMpNjgCTEe4
+        e7sXJa3e9vNRMnw83Bm9PJcbAf5E5UfarBKb+dFROBgEx266lDufezp2KgoO
+        iq+tJFxx7AkTCsmMH1gBSTSkUkKGHQI+y6h0duXv2oFlmUkq2lS0WSNtMIB0
+        k22w6N0YH3fu8N1OS0Fn7k41un28LUebxSrnaLNC7N0OLH0VZGlUoIKL2LrC
+        fa8soyJDjFYyYwZ2PkunKBJGMuKNo95jx7WBrvQ4cNHS4GWmqChTUWadMQ0H
+        eJMxDd+TTDb35NHhYOuKPlrDGy9NUS6DWqxyLoNaITbzo51+mKr+dPn28TjY
+        d5k7FCWNJhk5OKTQCuS9IkwZALxAVhqjJNIiC22YpaX3qyxaH7zMHBVpKtKs
+        d0R4o5vjItg663SjhvHng9trdIe2708eyrXY+0Tl3IzTCrG3rVgGXef6016e
+        iVO9El3KCXWceJyFjMZjYICEBogslxLQKkY0E1AwlWHl79qIZZk1KtBUoFkn
+        aBjDm9y6kicRkaIxfD54utqNRglVvWH9rFxIs1jlXEizQuwHP7ocRsFe7F7b
+        YOXMyVthTSe9p+fL7ZMgGHHQGsgkF5o6ABH0eZEwdMB5IRwmCEvmyg7dFN+f
+        ZYmZKgJVBForgQgHmywVfryRVjdOnmpJt0eOXpJrNAofy5UKL1b5kUCrxH7w
+        o6YaT8aIL7Ofe3FsfzsJW+3CqZUz0BtDACZKUUeJo1ZAnOdbDgolJRbYCEXL
+        Lu8uvC/LMqNUvKl4s96JqY3yhh3cnMTbR206vLi9ermJOs+nw5CW25dlscqP
+        vFkl9pZa6bCVmfNrUHPdrsuLh4/CbhJHxXdokdgQ6Jw0FhOdj+t4DzhjBjgH
+        hHPKeO+sRWUnwovv0LLEKBVvKt6skzdCIrLJ4uFmPdpzdzejl1a/O2qmW493
+        e72XckM5i1XODeWsEHvrJxFctidbzxXFC4PKaIi48xpwqb21GWeUNVwrZiww
+        DkKJoCmNl8K1w0tsUOGlwst/jhf8KV6YpJuck8KdUfvhYltc13qN+GzvYvi0
+        93AyLlc7vFjlR7ysEpv50XVkXfLkVGG8eEs1kAIqJSRFAnuZNzGHwhggstDF
+        UAm0Qb50YU1BuiwzQUWXii5rpAvCRGy0t6dsXuu0ya+vYi0aiT09qd+jnXK9
+        PRer/EiXVWJvwUv6a15TU0/C4g1qmM8CF+KY5dJZDL01xFsNLc5+Q4JQIH2W
+        MZXfwLIgYJZZoQJMBZh1AgYytsnsCF7euJa+6Q3ubp+OaW3YaJzs7pRsULNY
+        5UfArBKb+VFtONDjoOYyQ3bdeDrZXXhvOY2xINpw7AAFCBtMEKIcIWIRzTjj
+        MWTKK8z/pv1XlpmjIk1FmnUmSoLBTc5040Hn9HT7dtjswL24fkRP7a04uSuX
+        KC1WOZcorRB7C2V+7QWXcZKMg4PSDYSBdIBALAzQFmqIUBbXKMuk1cASaIWU
+        Bgpvym70VHid5RJrzPz7SzfsTT2CvjrKlyjzhpV/6l097A2+oYcB7nZeth6a
+        /W1G2ckRv1eHt6+2+2fs/cClf1Lwj8lNsl9eP/KX6ZX8Jn/ddPJM4+HE+aJh
+        t/t6Oo1TNTEFk7+8etC7v/X8Q0xUzv+R55f+WPzxvvzy7/8DAAD//wMAKEXn
+        difkAAA=
+    http_version: '1.1'
+  recorded_at: Thu, 28 Sep 2017 10:31:56 GMT
+recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/album_find_2js3lkzAjWpD656NK7ZaJX_tracks.yml
+++ b/spec/vcr_cassettes/album_find_2js3lkzAjWpD656NK7ZaJX_tracks.yml
@@ -1,0 +1,110 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.spotify.com/v1/albums/2js3lkzAjWpD656NK7ZaJX/tracks?limit=50&offset=50
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      accept:
+      - "*/*; q=0.5, application/xml"
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - Bearer BQA0P-TuSn2tg__j7GK4WEjMYUp_fS4F3NdPPGjXkKS4Alhv-ywIaEEVBvpPlX7rKHkZyVtRSYObRpTb1sz9CQ
+      user-agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - nginx
+      date:
+      - Thu, 28 Sep 2017 10:31:56 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      keep-alive:
+      - timeout=600
+      cache-control:
+      - public, max-age=7200
+      access-control-allow-origin:
+      - "*"
+      access-control-allow-methods:
+      - GET, POST, OPTIONS, PUT, DELETE
+      access-control-allow-credentials:
+      - 'true'
+      access-control-max-age:
+      - '604800'
+      access-control-allow-headers:
+      - Accept, Authorization, Origin, Content-Type
+      content-encoding:
+      - gzip
+      x-content-type-options:
+      - nosniff
+      strict-transport-security:
+      - max-age=31536000;
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAOycW0/jShKA3+dXeHnY88IOfb+MdHTEJcP9HgiwWo365sTB
+        sUNiA5mj+e9rG8hMEM6ZdKQ8+YGW012ptKvLH13Vlfz9KQjWeiMXrgVfioss
+        G46/bGyoYfR5PEyzKJx8Nulg4xFuqFjng/EG6o9xfP99s98Z7jDKTg75nTq4
+        2chGytyP/0rDcOyyPyn4dxwNovJibb38gChzg3H5Cf8N/i5eFz1qlEXjbKav
+        6HXPmRslKv6Wj+Jq7G2kGHudz8w806FLZib6onaDXXT67fOH/aMjrmB2Dq7V
+        cHJ0uPaq7Mf62+f91o2/zLRO51RXZCtN/ySWqIGrBNs9FxyrbuKyyARfIxfb
+        8U+pbDJ8kXr59J8D+Siq+l8n+eVl/Mu8G/4R/G/91eiPKoqVjt23gRrduzfz
+        r21erK0Ha1unVVtdb29W7VHVVv3bVf9Odd3aLtvddtnunZTt8U3ZnuyX7Vn1
+        3rNW1d6W7eV12V5dVu3t2nQ+Nhqbb0k+0G5UzgS/decjlUVp8u3FZyDlTL6N
+        uedhHJkoKwdCFY/dtL/Gc37Pbyr/3SAx2Z9keefk7E6d0NaVAO12cfeffnGa
+        33KZl6ehTt2rold/mS809ZZNk+bj0lN28yhTo7fx4cg9Ru6pvOuZSQ0/j41N
+        ivlsDIb4P69SG1IRSBBwgCmApNCMcRsaYRy2BBqHOIIixJD+ZSL7J1UGGquQ
+        spgS5ZSCyqJiISzGWkth3qZQ3ewvq0jf+t9cuBJ4k37vv9Xgl3rD/1hviNEQ
+        Y1FiSCAZWAUxqE6+P984MWH6so/7T5PrpNPKvYlRo26WGPOFZrxlx6msF6Rh
+        8NWNbJSoxAbWBZcqH4/zkfODiFEYU0csdU5xrgADkIZYWigUcyHChjArRUiW
+        ggjzgEj9WjQQaSCyOEQ4QavZduBoiz/G153oJIuTp3uoGD8kXW+I1Kibhch8
+        oam3HKWPLoiSICu85rKnbPo09qOGlVgYa5QGAAJlubEYGImAtihECBhLBWEM
+        uaWowT2oUW/8hhoNNTyoAQlYydYDXoiJBtklbWUXoSA7T2n/YfvBmxo16map
+        MV9o6i1bUVbcYNB2auSJCy4LUGBrlbNaGamLLQfimApnWcgwNtLRkiDL4UJ4
+        4KLe6g0uGlwsjgtImVhNpNKNTse7lI7MUefoFNy1SHd4DvwjlY/VvYtU5gpN
+        vaUT/RGcKBd0nAu2VDRKglv3RxwHx8VL13WZH0IwAIhSwi1DDBIlSQilIYIr
+        LoA1xX7ECkowR0shRPrEKbUr0SCkQcjiCMGSrybZwVx0cErSNpxc7KEBOnne
+        7ZxPtDdCatTNImS+0NRbbp3q/Ss47a0H1ZUfMWCx0+DIhhBriTmxACkcKup0
+        qC2jmAnCFeVmuU0HBB7IqLd8g4wGGQsjA0kK2CqIAW949+lhOHm42v8Ojvqb
+        qHd3fdHzj1E+VvcuRpkrNHWW1vPQjaKBSzJV7DTyceEyZbLDjxxCaQ6I0c4A
+        ARUwzFFHADQGQl3s8FDIKMChWJIc0CdeqV2BhhwNORbfbCCB6EqSovTqcTi8
+        PT5/BNfsu1ZbB639R9ryj1c+VvcuXpkrNPWWY6eSKOnGbuyZ3QiVo1wjzqF0
+        oQDKkdAYrEMZOhlSqhVEDhYiy+EC+cQmtVZvcNHgYnFcALaibCih4fWZORtA
+        gvOn1uBqM0u3+nv+pRsfq5vFxXyhd2co4+AouneBCrbSLItdeSi7GyWe2w0J
+        GEJaE6YxoFQprrkkBRQ0LSs8QEilpVYuV8cBsQc/6peh4UfDD4/cBuKriVTY
+        zu3pAz8ShubbV8dbd1f3z0et0D+38bG6d7mNuUJTbznPnUtKXlSHsMVCdp3n
+        vkMCg7ClWmtFpeRYhkQqxK1kFikJBHYW2+JvOW4QnwRHrfkbbjTcWJwbAkOx
+        Gm7c58m2PGDp0TW/v8+v7nLZHRt/bnys7h035gr9PIWNcxfcprkfK4jWDKoC
+        D9gaUfw7lxZSV8AihIpgJwogAMcBXJIVPsWi9SZvWNGwwoMVdEV7DPC9rfMd
+        trtzOzrdbE0cPL/bG194s6JG3Swr5gtNvWU/2FbJH1nQTnPTK6ERbCaTQepd
+        I6qRQQQYgCyVWMEiLMCUstARLkNAhAHAWgrkcvDwKRKtX4MGHg08FoZH+R9w
+        JelQsPnQ357IsxsJNxGNkuO9+zZv+7PjY3Xv2DFX6KezPKXBYZTYcRmjnLl0
+        GHtSAzFMAVZOIqvLnQZgUAtpy8yGciGgjGEBmVlyy+FTJFpv/YYaDTUW33Iw
+        saLScjQx/OZuFB/3xU4/7ex13dZhvu+NjRp1s9iYLzT1lr30KcjS4FJNgt00
+        tXriSQ0uKabOCsKpgS60CnJGYcgVsQprEjLrCoose5jiUytab/yGGg01PJKh
+        XKDVlG308gRfPPNw/xzGx6NW6+lsTzr/so2P1c1SY77QjLecRN1eVgUpL0HL
+        hRu4ynZ+SVFjXWgwNURYayjlmlJNCOVUUIA0LpAiQm7EcvzwKRStX4aGHw0/
+        Fo9VCF3Rl2JD2zsYCCp5+nC5ey+ebsM8Qv6lGx+rm8XHfKGps3xNR0HHBZsj
+        V52mFGFL9+1kZSvNbRp5QgRSh40KjTHIYSWgcpCGTMswxI46LgmlVCpploII
+        8ikdrV+MBiINRDwKwKBcTbaUnmf068mB6B9eD+IbuEX3In5+4k+Rj9W9o8hc
+        oam3XBY6k64LWhPfk1hKCVMMOBlywDnlmCCgaGi4ldapAhCGCkHUcl9OQT4F
+        o/Vmb3jR8MIj1cERWc23Uzrj4/Sge6zFtb66bxeP02XnOvU/if1Y3buT2LlC
+        U2+5mcTpsJcmLmj/+gAuhgzHgbWMaa2tslYDSEImKCHYcCEpgNoIJa1YLk5B
+        PkWj9ZZvkNEgwyPPQVcUqPCdAYqx6MHbr8/brdbhSX9z+8C/eKNG3Swy5gtN
+        veXO6ZHyTGhYiDSSQDBJkZOShkhAoqh0wjlpkdIGWQfgcqDwqQ6tt/erz65V
+        PxtYvpNWDrCWFOtcvkzyOK46Xn5h8BeJ6q7TfPyPj/UCv1/4/ucLszRTleWZ
+        /PTj/wAAAP//AwAeSXOXMlEAAA==
+    http_version: '1.1'
+  recorded_at: Thu, 28 Sep 2017 10:31:56 GMT
+recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/album_find_2js3lkzAjWpD656NK7ZaJX_tracks_market_ES.yml
+++ b/spec/vcr_cassettes/album_find_2js3lkzAjWpD656NK7ZaJX_tracks_market_ES.yml
@@ -1,0 +1,124 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.spotify.com/v1/albums/2js3lkzAjWpD656NK7ZaJX/tracks?limit=50&market=ES&offset=50
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      accept:
+      - "*/*; q=0.5, application/xml"
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - Bearer BQBCu8CXSTHFTd54ZkGNqcB-cNKdDT_jubP864sUPLB9zWdhEqKXEeRwSy_A6vz3djrVxrr93THA5-DD5Ff54Q
+      user-agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - nginx
+      date:
+      - Thu, 28 Sep 2017 13:04:46 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      keep-alive:
+      - timeout=600
+      cache-control:
+      - public, max-age=7200
+      access-control-allow-origin:
+      - "*"
+      access-control-allow-methods:
+      - GET, POST, OPTIONS, PUT, DELETE
+      access-control-allow-credentials:
+      - 'true'
+      access-control-max-age:
+      - '604800'
+      access-control-allow-headers:
+      - Accept, Authorization, Origin, Content-Type
+      content-encoding:
+      - gzip
+      x-content-type-options:
+      - nosniff
+      strict-transport-security:
+      - max-age=31536000;
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAOydW2/iSBbH3/dTePth56V3Uq5yXdzSaJQLuQIJSYCQ1apV
+        rgsYjA2+hMCov/sakvRMAMNgS7BIvERgn/zxsf/+5ZxyVfjjH4bxpRMq/cX4
+        lr6I40H07eiID9xfo0EQu3r8qwj6Ry/mEfecpB8dwW6EvN7kuNscnBFMqjf0
+        mV8/HcUhF73o90DrSMW/YfAvz+27sxd9HvbSTaWHL1+nH+XGqh9NP+s/xh/p
+        +3QLD2M3ij9tS7eq11iFPve+J6E32/exJ933fmSfjjgYKP/TIb/JHpH7Zvex
+        Nrwqlyk34xpo8MG4fPPlXezH14/P+1un4O1IszR/arlyprQuzOd9NQt87Cij
+        wtu+il1hnLvKk9GfUfF48Bb19ul/7khCd7b9/SC/ve3/tirhH8Z/3379i3Qj
+        8d1P+o4KpyLoY3MS8tgN/O9v18jElNgf+9TrwHOFG093aO5F6uf2jCv1967T
+        zDlHYFRVlcdGjzrnzlmXtc6vhqDXej/q9w/6O5fozYdZcu9C79dnTVD0feDx
+        MXe82emPw+QjYc/1e0p+12HQ/5RuYcu+nQrLs67GcdKs3j3zKi7VGXh8PL3N
+        59j305EhOW/YdWE/rTiTzXbibPe3VXl8XNKft8CxCJJoav+LxI15+HERBqF6
+        cdVoekY/pTr4NRLST7M86g/Qv9+jjhDTJpHcxJo4jBHIhSQWMU0pTcQEY8yC
+        NiFa/y5c+RvmwhSSQy4Rtrji3OQSpm6XCDmOzcTHIcyS+cutgj+2LzsZGaci
+        290/vh4w+P+PQRvYBGwDg2ZD2c/NUlJ/uqi9JsiaPL+I3nNuDGbIfcbgmqBd
+        YRA7/uT1SbExcR66qDsaN/z0IAthMENy3rDrwjbD4Ko8FjA4vQXOFI87RqCN
+        cxVK1+e+NKQyHngSRUmo8pGRpNyTHEMFuS2lTRwbIEilRRB3BLYl4hhrBmUh
+        MpIcZMw2/IGM+0BGmv5J3U6B2LKiSUyFc1qPH6gnRdBCYZi/QFwuN1cgrg7a
+        FRmRe0JfvEbTrcaeP+qZnNAbq12IjBmS84ZdF7YZGVflsUDGcvCijCvfmN4K
+        Dx0ug1GUD4VAcYUcQYTFsUrJh4WUiBFF0p8OommNCDglqhgKaZ4iMdPhBxTu
+        BQpNC2ylSARP7ajN3HGHX5pRMiENeH/p3OZH4XK5ORSuDtoVCs17NnZA/IBL
+        8b1m1tko6A5Ph4VQmCE5b9h1YZuhcFUeCyg8ceP05BmPioc5GWgpgiRICWib
+        WDjMlCZUgEmtObGl0ia0FNY2J4UYyPIwMNPaBwbuAwNNTNhWGIhur0PvtF6t
+        9k4HfvlifEwoCR5yMzBD7jMD1wTtrFFuu7fRBcahKDfLt+C5ZLUHNVCsUV4u
+        udAorwnbsFFekccCA5vuL0aVK6OplHHC3dA3WuoXzzMq6VvVVnE+LnIoJAAK
+        pmWgBLYSUBAI03pQpe8xmuIPmYA7uBAX7RxczLb7gYv7wEXLpNsZQESV8VXj
+        tHQVg4uX21ZillvgfpS/NsyQm+Pi6qBdcZEo9/rWCh7N8f0l7MPq60WzNnYK
+        cTFDcsGwa8I24+KqPBa42FK880/jtvPVmL3K+RxFOLYDTKgJEchimKm0MpQp
+        4xiENjdTLFIkheMUwqAJ8nAw094HDu4BB6GNAdkGBnGgz9xWol/pBIuXmizF
+        XFSD3BjMkPuMwTVBO2uRn2h7NByMh/WrCSh3j2HnuXHfKdYiL5dcaJHXhG3Y
+        Iq/IYwGDpdeBCt2+8mOe1oRJlN4H0wHEnFWhsARTNk0rQslTFAKsAAdSIqKY
+        REJzW9kmo7wYDs0cOMy2+QGHe4BDEzKIt/L0BJ0GjZ5zbkF3SEYvl+WITI5f
+        80+vyZCbKwtXB+2sXa6/DAatSu0FNMjE4SfXpasXXCrWLi+XXGiX14Rt2C6v
+        yGOBhxXFfddveyrKOWIoKKWa2RBLYadM06lxmSlBus0iwEKaEUmoDYo9NTFh
+        npIw09oHBu4DAwHZ1mOTLn6qJKc3/omGL61mv35yCR86+R+bLJebe2yyOmhn
+        UwyxbtyJu75poWRU6teP4+Cke1lsiuFyyXnDrgvbcIrhijwyniBHRtntKePY
+        OAni2FPGrTYuXD8fFG0FBbaRRYRAxJFECQdKTjEkSklNkGkBy5akYJ+MckAx
+        2+sHKO4DFBGk22mU4fNNI8ZXg+h0pHplzl7HuE3ruaGYIfcZimuCdjZeeNa6
+        HdIyEzg5rVdOnuu913JJFxsvXC65YNg1YRuOF67IYwGKtUQpfwrB2bwa/sLb
+        KmeFKDGnhArBLKktjAWwbaYcSYVmwLEwFdISRJsFK0QrBwyzPX6A4T7AkCGT
+        bQWGiHp1c8gBR4Bdtfuy8nrdua3k75KXy811yauDdgbDXuKf2tckKDdor5fU
+        nxO7HYliMFwuuWDYNWEbwnBFHosTa7xEGa0gyQdAIJFCRJhmyrwUayYHtla2
+        jTnGpqOBQBCmtaEqtvrEzLP8JNvXBwDuBQDxlqpBa9ypVM5wD97173nrXIxr
+        txdx/mHCDLnPAFwTtCsAgsmjk5yRi7NWeHtcGiuz9nwZ3RcCYIbkvGHXhW0G
+        wFV5LADwyjjl/i+x8RgkojMloXHsj/tB3lUnlsM5lpKkBaHUzAaQ2paDRFom
+        WsgRaZvMECbILlgS5ll2km30AxH3gIgUmGg7q056d7DdiX1QahDbw+d6Uq7U
+        /Pxjhsvl5sYMVwftDIjHw+7p2L57ss1jiF2/ctl7pI/FgLhccgGIa8I2BOKK
+        PBbX440C48b1ZTRtke9UMPByopBSqTh1bGwjIRRz0r/pSgMLS0tbDGmiqUJc
+        I1YMhbmWnWRa/IDCPUChSdiWVuBZ3oOWIZXHqnVi9UijacuHC5C/OFwuN1cc
+        rg7aFQvhWNCn59CrdNlZN2hettXJTXJViIUZkvOGXRe2GQtX5bHAwstglBaG
+        xgMfGxdBIJ1xThSanCmpENCMM20KgTGVNuNSa4ItoYnNgdZcFVt8YuZZfZLt
+        8AMK9wGFiDK4nYHC/vlZ5U4NQ6fi2pf2U1+Au2uRf6BwudzcQOHqoJ1NL+wk
+        Prp/pfqqZnqVsFQa3V3aqtj0wuWS84ZdF7bh9MIVeSz9Nw1VN62aZj3yW898
+        r/pqZtB8g4fUsknaLBPLMqVgUHJHctuygdLM0sLE0/9qo4VVDIq5lp5kev0A
+        xT2AIrXwllaetAfN4WgyaQSh33s6c3q6fn82yc/E5XJzTFwdtLMphlp2rvsM
+        2zQYPlz02KilExcWm2K4XHLer+vCNpxiuCKPBSaeB6HRVMZxqGbPktOuuR19
+        PFg+CRIZuDnRSCBPG2abUwApFZA7BAHINWQMU62wsNLGGUMKC6ER5lqNkmn5
+        Axr3AI0mNO3tPFchw1vefKy+BPVXj3oND54Puqifm40Zcp/ZuCZoZ2ysxfi8
+        es26N42+92Se4EuX1qrF2LhccoGNa8I2ZOOKPBbY+JD+jt9WRmmcd3aNIDpl
+        GYIWtjmXVANMlZP6lzFhWwBZ1EIIIoWKQTDPGpRsbx8guA8QJBRa2/nfhsNj
+        omjCx7VxG1WsSU3ycTP/mrwMuc8QXBO0s9k1zagSXLcrDms49d4j4Pih2QiK
+        za5ZLrlg2DVhG86uWZHHAgSfxl4w6AR+Wh/+lSobDh7anEGqKGMKSwtRCqVl
+        M8S54MLhFkUiBR5xVDEO5lmHkm3vAwf3gYMIb6lRxu3zq3H14YSVk1vuTV4n
+        TdCu5i8GM+Q+c3BN0K44SM/60EOsY7bOX09LpZtq9/j0utgswwzJecOuC9uM
+        g6vyWODgs3JCno9+DCHJBREUW0ynXTAGzMJK24IDS9s2FA7RkpqgGP3yLDjJ
+        NvX7jfhl9oUA09/Es7vsi596aPrWTzxvtuHtuwP+EjHLOkiitaza4JsJsr+Y
+        IA5iPrsGxP7Hj/8BAAD//wMA/LaebhZhAAA=
+    http_version: '1.1'
+  recorded_at: Thu, 28 Sep 2017 13:04:46 GMT
+recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/album_find_5bU1XKYxHhEwukllT20xtk_market_ES.yml
+++ b/spec/vcr_cassettes/album_find_5bU1XKYxHhEwukllT20xtk_market_ES.yml
@@ -1,0 +1,111 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.spotify.com/v1/albums/5bU1XKYxHhEwukllT20xtk?market=ES
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      accept:
+      - "*/*; q=0.5, application/xml"
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - Bearer BQAMomziY8pvmTWlAPjV0rA1NLmlAELE4bRD60-SGvqfv2gjVJ0hWXsbzHWD24C6XHs-mHnqygmdS8KkxHkSZw
+      user-agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - nginx
+      date:
+      - Thu, 28 Sep 2017 10:00:09 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      keep-alive:
+      - timeout=600
+      cache-control:
+      - public, max-age=7200
+      access-control-allow-origin:
+      - "*"
+      access-control-allow-methods:
+      - GET, POST, OPTIONS, PUT, DELETE
+      access-control-allow-credentials:
+      - 'true'
+      access-control-max-age:
+      - '604800'
+      access-control-allow-headers:
+      - Accept, Authorization, Origin, Content-Type
+      content-encoding:
+      - gzip
+      x-content-type-options:
+      - nosniff
+      strict-transport-security:
+      - max-age=31536000;
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAOyca0/juBrH3++niHix+2Z38SWO7ZFWK6AtMFwKFIbC0RHy
+        tQ1Nk5Kmhc5qv/tJU27TJik0IzhISDMvxn7mbz/237/auf3zi+OsiUCO+lfJ
+        ZGDWnC/3/1z7PauJE3+YDKfF/3H+SUvSMnOXmDgUwdUoDrKaWXlaMxxEiW8n
+        mUg3SQbDL+vr0cCEf95X/Kmi/vpMcp3uhwwEZy1vxwDaHu/sspubnZ21TOrf
+        32ctdWNjfxATA/8HrTG8lxsW6d0r+TrTKQ8KRX82ABuxSnzlHERhz0yGD9VP
+        45M1+VA8iv2s9L5fX2a1X4rz+9f5bza2KhpMYr/TnRveJB3fTBABiJ1a1PfD
+        yDkxKoq1H3acrcjZT/RCn7Yy5d+riRw9797jNPv62SyvjQYqi2WMMsQAhpST
+        Wdu/FHvjhc6Y+m6dyDPY3ru42+nWb0e9IDhF4C7pPTXRMWFs7ods1tMX2WSq
+        PSwSz2TuPVIa0hcd8+N0dc10CqdFngseLRH80J+0N0qHaVfWM4F1l3mYQwkI
+        Zq5FiHPhKgAllZppIhkhFgFtLH+YoFtfJ937Jn6Y5qfGMXhp4xAoKl0KCMBI
+        Ks61QBojoxAlUEhstfZcJYhdaDxtoqBxz31p254lUDLrSUVcIJjrWsOpQpAJ
+        T2JJFbSu5ZzlJP7MmYGQZtZOjrFnE/W0lA9mBYNoMApE7CeZBxHLCmMTGDE0
+        V1ok5nG1/AF4+mdtIeBqEBvlD/0ozEK1mMxiklio3nOvV7bj+kzy78jaoUn+
+        Ar8Gft9P/iLg176Ie2lJvfXItcT0f/BjPrPLuf1T2f2M3z+X4S/m+AtYXsLz
+        1ZieZT2zZyag/aG6Ckd9aeKpEHyqGMUiST10NZs2RBHm7mOtuRsEvvKzRWVF
+        MDTPagon72VTl3lqnTS+aW+vHXeafBN/PepvseZRmvpDBo/NvWTWZi4tknyU
+        esDqsrDh1SAQEyGDbFKSePSUfOCnk6evbBz151L/CZ6eDQy+tjE4bXi1Y9Xc
+        FwnrbIe0jla39P3gFMguOnp54KNdM+kyt2YBX8ozeprqx5VSi5xd51yEoXD2
+        wuj276e5Sck39s3t1TzeB4947w/wH/dR6xQbAAQQhCvGqYSeBtZgoK2LLRVG
+        pr93FFCu/1a+/osIBVX6EyQ0Jq4wQkChkcexxlhKztRTJ7KsctdUwcgUjEvZ
+        Enj8cfvE6Jw5/s8xCiBF3tthFG2cMv+kOXQbxyNTGyPFbtBevRJGCyTnMbo0
+        7H0xivaDcazDfYHbchNK9/pitBUGlTFaILvo6OWBr8VoeUY5GD1xzpwDPzQr
+        89NyT3kQWmDSQ4EB6bbbQm651dAK6Mn0L/IYUrwiP9GK/Czz/ic/Pyo/PUDg
+        2/HTuz0827w8PG/c6bPtyHrjnpj0qvGzQHKen0vD3nkbGm71zk52091Sq7mB
+        fNlwOQ5t9W1ovmzONnRp4Ku3oaUZ5fCzGRqnEcXOadc4J5HQK29DAcWuYgxJ
+        g6WV0gimhKcoQ4ZAV2IorJJIk4oYxStitGwJfGL0o2KUYvKG21Aafh9esHEQ
+        7unxdrNeB/H1RvuyEkYLJOcxujTsvbehepvfJfXvW90IX2/FhB146uYnbENz
+        ZfO2ocsCX78NLcsoB6Mb8fQqaSBWxaeQIN2BAmlc6kEmXM8TkEMuDAIYWUuh
+        8rCBxKuIT3dFfJZZ/xOfHxOfkBEXvCE+4TWPzXddxxdmi056yWV7C5p+JXwW
+        SM7jc2nY++LTE149DM3JweVNsHfOD8fN1tlmrzI+C2QXHb088LX4LM8oB5/Z
+        ldDE2U2cjSBYlaFEcqCAchFKT++ulpbydDtqhXEhFmR6H04rogSqyFCyIkPL
+        /P/J0I/JUORiiN/wJE9OT7ejNgUbjfh0PKonNzt7mLaq3VDKl1y4obQs7H0Z
+        SjfinTE+mSB9vtO4PWaSbEbNw8oMLZDNcfTSwNcytDyjHIYeRn860DlKvT5x
+        NsKk+/wX7pWbUYWFixhAgivuWQUpdBm0BhnsMQBdyl2roa56S8lbEaRli+AT
+        pB8UpJAA+IYgpSSk/ViYg4k6bgZoWNu+EKem2lk+X3LhLL8s7J0vifaHx3DD
+        xCe6Ja/jzR5uuOeg+lm+QDbnkujSwFdfEi3NKAekB0I7rWgU6uGqAGWYWeZi
+        kJ7YsYaQYYuYpJBzY5lISao5S49erlsRoHTV03yJ+T8B+jEBChkELn87gLoi
+        OYg3hN6kusXuQj62PX50XAmgBZLzAF0a9r4AdQesWx91ht9q0vRqndqOeyw6
+        Z5UBWiC76Ojlga8FaHlGOQBt+LEZ+tqsik8OqYHSMKAs5izddnIANbbAxcJ4
+        HhaWE8VcKCvik62IzzLrf+Lzg+LTgxDht8MnYF5/0uIxoRfDffl1cAZOO3u8
+        Ej4LJOfxuTTsne8ljVnb2/euQU+eHbVrl7dJe9yujs8C2Zx7SUsDX30vqTSj
+        HHyedye/aeciGjnNMJg4WyIInAPjnHdNOC39LTbOjt/prvzEk1CeZ5DilGtC
+        tBE4RanVGhIzfcsEG2WYwJRVPd7zFfFatjQ+8fpB8coxwOAN8XqoT89a7pl/
+        eLF1GJJG59vN3vFFNbzmSy7gdVnYOx/vwejrYbCze21rpu6OY9bhdvATnnjK
+        l8053i8NfPXxvjSjHLy2QjFwmqPEaVpnN1kVosBjUCuiXQG0ZQByL+Whca2g
+        1gDCodbEM5BWPeJDsCpFS1bAJ0U/JkURocR7w00q2t/WTXKQNPRk0PVR3e9u
+        HF5uV3vuPl9ynqJLw96XohBe0tqw//30dm+3Llut8Oh2B25VpmiB7KKjlwe+
+        lqLlGeVQdC80xmlF03cxVySotIwYyRHQiklqqavSI77kkijPMjp9/l4DDGHV
+        B+/hqm8ulbn/k6Afk6CQYf6Wj4yStmmYYUMm+4P2991vtcPjI4TCavfr8yXn
+        Cbo07H0JChLPnN9dNnp9xmuj02uWfEX2e2WCFsguOnp54GsJWp5R0TNPoXA2
+        zfRUH6/MUaKh9pDEjCLgEs4RFVAZiSzh2jVEUQkpghRU5eiqbzCVrYHHNbyW
+        vXQ//d/k4csK4f1HNcJRENwXzV7RnxY+BGWDEI2Gc4FJlIhg1utfHr5kkffB
+        lQXwTKu+FH0T49//AQAA//8DALijxjK/RQAA
+    http_version: '1.1'
+  recorded_at: Thu, 28 Sep 2017 10:00:09 GMT
+recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/playlist_find_00wHcTN0zQiun4xri9pmvX_market_ES.yml
+++ b/spec/vcr_cassettes/playlist_find_00wHcTN0zQiun4xri9pmvX_market_ES.yml
@@ -1,0 +1,623 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.spotify.com/v1/users/wizzler/playlists/00wHcTN0zQiun4xri9pmvX?market=ES
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.1.0 x86_64) ruby/2.3.0p0
+      Authorization:
+      - Bearer BQBj_AiSFlKCkNIMbCWEYjuJLl6n76QmVsHU6MGDgTUBLZqNiKZ4ALs6Kvm6ulbsW9O81JDdIHyXBndXyhUOxg
+      Host:
+      - api.spotify.com
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 04 Nov 2017 12:38:23 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - timeout=600
+      Www-Authenticate:
+      - Bearer realm="spotify", error="invalid_token", error_description="The access
+        token expired"
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, OPTIONS, PUT, DELETE
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Max-Age:
+      - '604800'
+      Access-Control-Allow-Headers:
+      - Accept, Authorization, Origin, Content-Type
+      Content-Encoding:
+      - gzip
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAKrmUlBQSi0qyi9SslKoBnKA3OKSxJLSYiDfxMBQByKUm1pc
+        nJieChRTCslIVUhMTgYKKJTkZ6fmKaRWFGQWpaYoAVXWctUCAAAA//8DAFAZ
+        BolRAAAA
+    http_version:
+  recorded_at: Sat, 04 Nov 2017 12:38:23 GMT
+- request:
+    method: post
+    uri: https://accounts.spotify.com/api/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.1.0 x86_64) ruby/2.3.0p0
+      Authorization:
+      - Basic NWFjMWNkYTJhZDM1NGFlYWExYWQyNjkzZDMzYmI5OGM6MTU1ZmMwMzhhODU4NDA2NzliNTVhMTgyMmVmMzZiOWI=
+      Content-Length:
+      - '29'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - accounts.spotify.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 04 Nov 2017 12:38:23 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - timeout=600
+      Vary:
+      - Accept-Encoding
+      X-Ua-Compatible:
+      - IE=edge
+      X-Frame-Options:
+      - deny
+      Content-Security-Policy:
+      - 'default-src ''self''; script-src ''self'' https://d2d1dxiu3v1f2i.cloudfront.net
+        https://www.google-analytics.com; img-src ''self'' https://d2d1dxiu3v1f2i.cloudfront.net
+        https://i.imgur.com https://d2mv8tnci56s9d.cloudfront.net https://aci.scdn.co
+        https://graph.facebook.com https://fbcdn-profile-a.akamaihd.net https://scontent.xx.fbcdn.net
+        https://www.google-analytics.com https://stats.g.doubleclick.net data: d2d1dxiu3v1f2i.cloudfront.net;
+        font-src ''self'' https://d2d1dxiu3v1f2i.cloudfront.net https://sp-bootstrap.global.ssl.fastly.net;
+        style-src ''self'' ''unsafe-inline'' https://d2d1dxiu3v1f2i.cloudfront.net;
+        frame-src ''self'' https://www.spotify.com https://app.adjust.com https://itunes.apple.com
+        itms-apps:;'
+      X-Content-Security-Policy:
+      - 'default-src ''self''; script-src ''self'' https://d2d1dxiu3v1f2i.cloudfront.net
+        https://www.google-analytics.com; img-src ''self'' https://d2d1dxiu3v1f2i.cloudfront.net
+        https://i.imgur.com https://d2mv8tnci56s9d.cloudfront.net https://aci.scdn.co
+        https://graph.facebook.com https://fbcdn-profile-a.akamaihd.net https://scontent.xx.fbcdn.net
+        https://www.google-analytics.com https://stats.g.doubleclick.net data: d2d1dxiu3v1f2i.cloudfront.net;
+        font-src ''self'' https://d2d1dxiu3v1f2i.cloudfront.net https://sp-bootstrap.global.ssl.fastly.net;
+        style-src ''self'' ''unsafe-inline'' https://d2d1dxiu3v1f2i.cloudfront.net;
+        frame-src ''self'' https://www.spotify.com https://app.adjust.com https://itunes.apple.com
+        itms-apps:;'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JScgp0LjOJT/J1DDYIiQgszwoq
+        Tgo0cS4s8CiKcvP0cM9LSwqKN0+sdI2wTA13NnAP963w8nb3T84PqYzQzTDJ
+        N4/PzPO2KCgs9zAKDs50DPH0cqlwzHFU0lECWxBfUlmQCrIlNbEotQgomlpR
+        kFmUWgzUpWRlbGZgUAsAsvl4mZEAAAA=
+    http_version:
+  recorded_at: Sat, 04 Nov 2017 12:38:23 GMT
+- request:
+    method: get
+    uri: https://api.spotify.com/v1/users/wizzler/playlists/00wHcTN0zQiun4xri9pmvX?market=ES
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.1.0 x86_64) ruby/2.3.0p0
+      Authorization:
+      - Bearer BQCv4_bMAS0TXQwjRsbQ4CqpHrZFIHGnfbR_7ayEX9eWC0GWMxJKGOcoTyX-h4o7_inK8pqwH2SSiATIJDxAlA
+      Host:
+      - api.spotify.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 04 Nov 2017 12:38:23 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - timeout=600
+      Cache-Control:
+      - public, max-age=0
+      Etag:
+      - '"3a5a34ed9132ae0d22ac98cb21ec6086"'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, OPTIONS, PUT, DELETE
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Max-Age:
+      - '604800'
+      Access-Control-Allow-Headers:
+      - Accept, Authorization, Origin, Content-Type
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAOy92W4jS5Yl+l5f4YiHqlNARh6bBwGFhkRRMzVRc2fjwEaR
+        EkmXOIoqJNAf0S/3T+77/ZP+kmuumBQhd7qTdA8FMphI4ERQO7ac29y2rbVt
+        D//9b1H0wcSdjtJxXw3bY/chWou86gzc35IfWTcw/fbDsB33kh982DVxr22i
+        QTzq2WFfmftB5J0ajvrORu1e+LzrothHw5aLbvvhB24wjLrxuO0Gf4/WO51o
+        Go/6Qf047reHQSSOBy7So+5D1FftQbt3+7fwT/vtTif8MVI9G5mOGgzCL+zG
+        ySNED22T/K7we3q3g+QXxj0XPXTUtNMeDP/+4eWR3dPQ9Xuq89eo3xkkD/3f
+        4dPw+eAh6PDTl6/RGg4f1v78M35wvb9//vzvJu7+ORq4/p+T9vNzJ/z3i94/
+        AZjsmLND8HzSHvXIU78tH7rjqw9B7T9ffqMP9osnrv/6t7X6zid/7Y06nb99
+        +mgYD1Un+QwxSb/+4y+CL880CA+lHtrfPdMYvjzW4M1zDbIe7EVv275onSnS
+        Vbfu5aH/59fHdu3b1jD5CAPw+bmDHb97wPB4xvbCs/35ouBPAoVxVDKMuDVY
+        AU8s5txqAQiC2nuNtSRKqg+f9U3adtj6/CsSM0T/6+Vpeqr78vJ9aCTvS9T8
+        +opFDTUIS/rQdiY87YtsPOm5/itr2/YgscpfX3WcxuENsNFx3H34+nszXowF
+        Xo0PL//wn3/7fqkLr+CXB/q8RD98Opw+fPoOyb/58HUN2i+ffVa7lvxs7dXT
+        fHqXHka60zaJ4LA/+rSBBz31MGjFw78+/7LNy+Gem1z3mr0xvRhutSa9Z/0n
+        fe73OnH/tlXvn9/W6t3HcevP293u0cGuOu9u1Pl5Tz3xVr1x23af7P9p66e8
+        7uW9xX9++h3/I/Z+4Ib/Bf690+62h/8FAfj3rurfh4/qza+GHLrud+9x+ExZ
+        6+xf6uVd/oAApB8B/wjBGaRrEK8BePP5H38V1dPX78Ss92WJd+bVe7PUu5P9
+        /mS+Q4Xeo++e70N78FcnNp+c1tcz4dMvSBbnB3upTvDkb+z08ulfXx/ok9Df
+        vpPoD5P34Pv1K7IGqeswSFuIT7/iT9qsXwIyPGw0+kfP/HzrZG+djZ8/fKfy
+        n3/7/gmKrNDnb5Cl/weNn5etmPBXj7bjev1ptBfM3lW9H6W+mfflSX788Y+r
+        /klqLd8c//xbtQsCruLNfoyfpud7cqPu6VanWa+1y1uQDP3pC1JM+NsxpYYB
+        5kzC6dQPp2hc0prkW+TzeVl0RQquR7It/0RnW7v3bDTmnmyfD27Wu3jr8vDh
+        +xfi9a8utBSJ5kGW6u/UfV6HQqJvoMu3h/oKYRgBb4w+G8oIRKUm1BpIqJZQ
+        S0098AAaZqlmnFgljLGE/LiYXyFN+JUzt08Kvir8cAZxLzH1nBkLLUPhURhn
+        TAlkFVPYmgC9lDUo8+E+4a0iD8fInM/GEdIUE6CQEB4zIiSXkEOJTYCAFniP
+        iWMc+BmGm/GKf91z+4EXDIL/iz5GZ4FiNJ3pu2H4T3/cNi7646jfvm2HrRA1
+        PtGF48904RuW/M/vX6NZx9KbDZqIrOVtkdeHe+bBVtKeLXqoLbBpix9ocxxn
+        RQ6zmW5z0YPsh1e9VPMXcNgLm7/AiTTH4VXw6FpoBfKs8N2OTuia+as36upP
+        JA6+/tEoCUPEvb8+AXqIA7tkr37unh4CxWkP30DS18vatm/xenvQf2FGH85q
+        65s7kHMMBU3ft/MB/9SX48XZ/AnPDvX94RM+3+yfHE9O5NaR69nnxZnAJ0qU
+        pfYtMyggOPgrIWJKd9xr2vj5p5127z4wI9+P3+L6UvbQJzPh+sZdFz5MJsNa
+        Tx0/xf7qqnEXL7eFPpsqQ3XaDioi+nVrfOI/M3fGi8ha3nd7/Qp83Z/J2dZw
+        VnU67e8254eH+GHUUf328MWuSL7+Ud+N227y148n9cPXk7r7gD9+lvqTY0ss
+        hMhwB4Wy0nnCteTIc0w0NoR67ASC5n+Ytv0vqgw0ViFlMSXKKQWVRUxii7HW
+        UpjvmGfyrV/tbZTGSn+0XobtZm+ff34Owsyk/OgjIGcIrWER/r+i/L8f5ceD
+        Ca9t+LD7fGfvUOyctM8Pu/vlMcwM/ekMs5jwVzfQHLqxCyi2H8BtOewy3xoV
+        sktYj8d74uT++ObcXtzfbVy3yIM6K4VdZqhOc/OFRKthl4ST4Fm1dpYD6oRE
+        XlHBqPbaBrrEGeUKSOjeh10qabDykmlLA7FUgVJygw3ghiAjA7EMSAw4Iu27
+        sEtFgs2U08RSrIDijkNhiQRWYhBgHHSAK6r4kuxyaxRIyc8gkXk74eeTyAKO
+        YWEWU8DrzeEgC7jHhRhMngUWZjCUClQugzlv4gaFBAMBQcUMhvXjvcfn2k6M
+        ezcbu/Csrwf7rd7SDCZD7VugU0DwV2AwnO317k2/dnl2crdePzm+2ndn55NS
+        GEyG6rTdU0R0fgaT991SGUy921XZxIXMIC7fLsw/Pe8PfAKC1z+ck1DMfpvz
+        CQX5COFHFAgFWANwDYMVofj9CAW4rkGJzDHeP66dXj6J575o+JsSr6zS9Wdc
+        WRUS/hZ2Vb1BdNPudr9b0O9Xe77bqlxjVMgn6NHF9qRRc0/xjhofqT4bE9Wh
+        pfCJDNWpce8iotXwCecspNYDCwSRAjMksZaeC+6V9oBz46STHr3hjj+HT1gq
+        KSbeJ3hdY5I8jmGQeekNdshZpXnA7ew9+ASWAlBCGFLAU+ap8OGvAmmpncYu
+        8DGcxLsgXZJP7PbCuz4Yuk44+daifF4R/bHpOqMnF20GyWGQvAj/PIguzTfy
+        dsrP5xsFHMfityb5TnEO/5nvPRe7MMkxwMJ0I0kufA2vyqAbhwenkIDgUUjV
+        Fyb08vTS4MfHznT9+azn5CMdnuwvf2GSrjblwiRf8FegG1A88+E+H8lNszkR
+        9OD69JRuuVLoRobq1EhaAdH56Ubed0ulG7W43/Nt17FRraUGLpt5ML7wlQnS
+        DmLBbThfFXTQcIM0t1ZTzEHYdYozmWRgwPe9Mpm5gYowHEA+IpAwHMzWMF4x
+        nN+P4ZBt0ySNY4M2h7cP1zV325oKcVQew8nQn85wigl/dQQbfWWjrbazrlMO
+        w8k3RoUMhzyTMTzeOhR37cZlf7MxEXLn5LgUhpOhOs3PFxKthuFwjRzHlnLL
+        GICeQ0WVgBZLCJBF1isJLQLAvAvDccYG/gIEglxI5zAR3iplmBFEeYepBsZ4
+        58B7MBwptGQaS+Q0DcDNYqGo5FQYyYzE1BgXjqJwIi3JcM5cvxs4zTDuR2gt
+        2hvZ267rDaNNNY3+OHXdl7oNZ6NwsPClSUzeZvj5JKaAb1iYxBTwe3O4yHwH
+        uRCJyTPAwiQGckBxqSRm67RJErcBAK6axLDTjcmkOd6X+5qODvrtiSU3IuOX
+        znNnkq425c4kX/CXIDG7h93u89O2ONrFp8+70D2Pnzv35ZCYdNWpJKaA6AIk
+        Jue7pZKYhmr3orP2sOOi1341yXTuuuhj9INDnXG98ppBzHm9ssztysz3fi7u
+        QcUaXVVo/YbcA9tT395DjILmzYht66k1O4e6xHStdP3p3KOY8Nf9uxe3etFl
+        UrysuoOS8rVyzVEh+2DPbqdBaxegdmeaYF/Eo8s6OSyFfWSoTnPQhUQLsQ/M
+        3xh9Noj2kDMBBGcWSm6B5QE9WwEsCM6KYWsQJQHj21kguijAR1LO+XCMUiuE
+        94JL6znGRmqYPKw32mhnoWdOaEOyc6IqZB+Bs3lJGeCAGyoQZVwFeoQ80sRT
+        6H14XootgUuyjx3V70+j43gYXvmXbgEvNUFx34Qzsv8fg6g5TNoD5N+7LMtM
+        8jbKO6Rz5fuNhZlJAa84hwMt4j4Xy+fKMcGi3AQDCWS53OS8uR5ADwQS8cor
+        UnricP/k9FYcXOxMeXzeOr/VW1vLX7Ckq025YMkXnMlNXlWQ2Un7NmzyF3Q8
+        I+D/Ol9ovoC/JMRyaJU0TihPCABQIUk4ZcwxyqEg0CviwNIBf/j6vm7uiP/M
+        FZ0v4o/W4Cqn6X1Qd/hOD+3Oi6N5L+zNcOOkY+87/un+7nozPq+Ts4eHErsj
+        ZOhPx97FhL9xZ4HLQdz5RqgScV+IWtw79VsuNieP/dvutkWN63IQd7rqVMRd
+        RLSaeD+QXFFpOAWGauEAx4BoSAgzngFnBFeeG8vfJ6PJ8aRWgyHHgl+n3Ail
+        kQ/e3lkkHMLh6URyAfwu9fcUMcsQDc/FONSBpVgZ6AG1UElLEHaKByqj+azS
+        kiKI+0h32uMERH/8GbA6Zzf8fFhdwDksDKsLOLw5fGO2Z1wITOd98SoL7CnZ
+        rx3u8vPTWn+bTe9O9vH5fbxkbv3X/gbputOMXkT0W2nKaKB6gXs2w17w/9//
+        W0K+WJ4VFqYzAc3yV96mFDpzQuowODuGWNV0Zm+v9oTue/dUCN94hJ3Ts52n
+        DA41D51JV5tCZ/IFi9GZr471j6Sd4t+jH1+g/8xmOGTxlCbNEfLGakm9Su6F
+        oZAcQgCUAji8FoHMeA4IZMsznNfPODfDmbnIczMctGI4K4azYjgrhrNiOCuG
+        80VqxXA+eUj0CMHl4N7gzvF1tz664P3nRm1cDtjO0J22QYuIfl2y9d6wFfem
+        0Xbce1Yd97w82M6zQqV0h7FG51LVFMN348bNhbxu3OGLkuhOuu5UulNA9NXV
+        zcA9tKKzvnpQPTcooRo/zwpVrsCK5Wex/AU5JiKBWpTdAuEzx6RSVMwxuTex
+        jM2WG4zkLpDrje7D5f3l0hwzQ+1bkF9AsBjHvFT3SVv989etVH/kkq9XaT4u
+        SZzQ1GuthGESagW4Q5J7YQy2TChnFUUkUM13LY+ZvZbzUcmkQmZFJX+/FDVm
+        79zuOt/uyLG8HfceTg10u1slksh0/RkkspDwd40FD6Y92xr1B8MAcE3LDcIq
+        lEQscw1TdTtxfKbOatftMT4xqnt5Nz6tmWd2UmL2YLr+9KUpJvx1abbVuN2L
+        tvvO9dRETUvKH8w1SOUd3lftMuZql1H1DqmRRvd87/rkUA7Gh+HEWj9FG2W2
+        Q0zXn7FDCgl/XY6D9kBF267fV/03XegW3B651qiy2T46P7oY1Zp7vXrz6Gln
+        44Cf752Uk16boTqVaRcRLZZeS+eM6DDAsMROGoM4BQwSGZAgMFIBxAHyjDEK
+        tUSylPRaMefDWSOI9s5oB6AGFGPFEKKWc5n0xcXOCO+YMe/SDlEoxbVXPjwK
+        IBYBZBlS0EnADNRE4PAia4CXTq/d7ijbfqlB+Rg1RskUrq1+3H1Jsv0+IrZs
+        GCxvJ6zak/x67UkqjL9Ax0fTjQ18cv14OO4PNTvd2ex1yzF+hu404xcR/Wr8
+        63H8cl3797A1+u3w26bLr0GeHSqdavCsamznbOIGNz3MYmQPtmKx7CSYLxsg
+        XXfqBigg+iq+0RlGW/GkU8oGyDFApRtg90ne3Qxa+8ed28315h2LT9VuSQHI
+        DN2pG6CA6DdwpqyNGma3N4wHrRLe/RwTVBr/rR9P6f7R0YlvNjZb6rm+f9cb
+        XpYU/03XnRr/LSD6rd9mp/2stBu2oq12z5SwAHlGqHIB+AjAbrxzPb6z7Hhf
+        d66e/fFgyXkQXxYgQ3faAhQR/XYFkvRva3ZVp+NKcP15Fqj0Aup89/qiuzuk
+        98NN0fJn27fjyUlJrj9Dd+oFVAHRV10NRsaV5vvzLFCl9YtEbBa1foGI1BzB
+        q2Khq8Vqt3KMUKn3LxDFXNj750dr5wjszhfWXewUyDFGpTshPziz+E7IjzzN
+        EaQqEKJabBvkWGDR+1guuSi7gvG8UQPJ/yiquruKH439eutu7+ho/6hD12um
+        025sL99dJV3t24uyAoK/QncVXj82+PgJb9W3a+rxDNL2Fp0sGV38cnOdrjoV
+        QhUQXaAjfc53S+2ushP34n60037N4H+8/Z5RK5rXN+X1xfncjVNmvtLzJjiT
+        1a30b3grDQ6m/uRy74z1rpQ/OL55fHLyyJd4z5auP+OerZDw1615EXZgPBpE
+        65+tVc5dW65BKk1zZgTtm53J81Fzer092aHi/nbZznBf0pxTVadiyCKihe52
+        5s4khknPRmo5TNoMcqS84wggyqHi0EKnLeFJ6vOMiU2Fr0/mT3NGFggZ/CLC
+        2higkQjPpln4O+FWGuOgg4hYkJ1KXOHdjvdOQ2KtMlw4bpDhRHmmJEWcO4OA
+        E85TZ2Zdis14xb9nDMkVTjJReS1qPjjTVp2obtsvFztfU59fN6ev92477UGr
+        tK70eZvkHeo7j/DNBq0909rhGZ6cXMajfXO4VxL3S9edum8LiH5rfa36XdeL
+        ziZJ55QSMm/zbFDtrcODfDzcbLrrNj6px7Zl9tfX18u6dUjVnX7rkC/6jfI5
+        HUeNv5dx4zD7yy+cfYulKLmZ5nnzchMChAAhVQ8gA9v91sYzUF25v7WHQONQ
+        xuwgY976HBwmQ+1bBFpA8Fege6i7tU2fbuT5sxyT+wE46U326ZJTyD+bKkN1
+        ajJJAdH56V7ed0ufCNDum46LYh+OOb9gf6AKe2XOfq3no3x8jcgV5fsNKd+R
+        MR1zTGNxsb+Dzk4fm9donZdI+dL1Z1C+QsKvojET1bdRsxX3SxptnG+NCvke
+        IP1nidcft6dyz46eL/C+gJutUvhehupU3FJEtKpG/cYbbhHXmicNBSBxVAPo
+        tXMKEWYlNBRJLErI5Zuf7wmVNG2zNLA8ZIDk2DqpmLeMO2iwhsxYAwR7l0b9
+        Gmpmgtm8T2YaYKsJRB4q77UQOplIRhWFEL5J0V+E78Vhxx35lwS+00D7Bmsv
+        f9xynU48GbTaD69/+FPmIOdtm3dI/Mv3IoszkHwXOYc3LeBLF6MhORZYuKc/
+        p+C7AHsZNOS0DkHYNhDgqm+dCHEDqq6P98JGvzm4a8B+t5kxfGKeW6d0tSm3
+        TvmCxYoAa3HPBJMkO3wn1rr9Xbj1R2z8mjXOVw1oBdPASA9QcGyACmgYoB4I
+        LCTnYbmwBFBz6N+1GnD2os7XsB6tkVVjmd8QhK8a1n+fsvCeDevpqbgT12Dc
+        RpLv9Hs7J61p936jnIHA6arTzu5CosUqauYtWlEoOFuVdIJnxEnMMKXAOR1c
+        kfCQI42hJA7LGbcuFTast5Qz7BXBkmhFtMHIQCuccQEBY+a9o056C95cE/6U
+        hvXGAU2MoIQ6Y7xXCCjNPDTKcGakEchRyZYel/XdhovCUWxHZjiICnU+Lzzr
+        N2cTrJrR/ys1o6cBSpUd2282oAQAEAwrBtUoZgycttHk7JafjpnZ11sbtYxR
+        r/MErNPVvkU5BQSLgepPk5texjT98VIj948PzaHqR5eqP/jHh1m9G+nrH82F
+        sA3lhEMOAtBkBnoV3CdzyluskAAWIoA0R1iL5Xs3LoGwZ6/wXAibwDWwGgn1
+        GyLsVQeBOeoyq61Yfxyv851u8xa2G+yq0d7a4swuWxnyuWI9XXXqJWMR0Wqi
+        3AwEl0owDugQQGs1UAxQxQTXTlLliOWa4wAX3yXKnUye1dwE9M+s1JhjDxmU
+        EthAALQDnnqBKEbZkeQK8bUlBkOlIaLSBUqCBNWcAUGIdJIpoI0ABEmdXU1f
+        DF/v9ox7eAlW/zGzYH3pwHXeTlhVrP96FeuLps9wSknZzetO60mbbUA5rzpu
+        fbOlr3b37ke70F4cXo6f957jSW/5uHW62pS4db5gMYh91p415Ym/XsD5cLTT
+        hGFEOCKYEWYdBEqRxIF6ZIARWuAAr60pAUcvFaqeuY7z5YvgNbwKVf+GQJrc
+        H4xbjfVRrRMfPMXHUF00+EG/PCCdoT8dSBcT/saw26alXCfabitjWu1eXA6c
+        zjdJhXCa7Nf99XH/9Pny+EGJzfvt/euRKKcXeobqtBO7kGg1cNoQCiwhgHmV
+        TFUFCkHMtJLAEMkBtdY4brWclftQHZyGAhpBPLFUEx6AdDgQBGLaYsO9AC4J
+        ZUtM8bsUCSjtFWNESyAh045LrSwzkkjtwl8FVoK5cHBlJ7QUg9ON9iBJ9F+L
+        drsPcfhjOKKj3d3dN+D6J2SK5O2Vnw+4C7iOhQF3Aec4hx8t6kUXgt15ZlgU
+        dlMoQNnZIrhBAeMYg6oD27jNUOOGwe3p7cWjpGh6va33bpZG3Rlq32KiAoK/
+        QtI61+YEXB/W/D5ho373ugkuAmcrp0Y5XXXaDioiukCNcs53S01aT3O4OfNt
+        yWtW8fPy12e/4fPxEbEG6YqP/H58ZJW/vspf/34NVvnrq/z1dOS6yl9f5a+X
+        lL9eYf0y0dtu4xb2hzW1e1KfPo1Ob81wuyROmK47lRMWEP3WOdK+WP804M0S
+        2GCOARZlg4SA8ungl+IBWPUEITi918OtXmf3rru71bsRd2xyyzIKWOeZUpuu
+        9i0kLSBY8BImONeNvvs0R+izs33lfj9Gn4bX/uPDbi/aDHLdwT8+zCgvmEFd
+        ci5ttJDhRMYOhJNNGuIIJxIoDBwQLpkJ5TjCEGj6zoNrZ677vNlPCK9I0m9I
+        klbZT79I9hNs6/rWbm0Lj/r1mB8O642n251l+1F+4kgZqtPO9kKiFWU/4YDy
+        PbOOQmmx9ACa4HKN8U5ySaQgmFEJ8YwkHlzh6FrNHPRAA2U5lQT7JDvLcUyB
+        U84ZK5HnXPjs1CwkaVUcCRomkisk6o2FwPlgNAgYo9QLTKnwlgvNGKAzDFeU
+        I22q6KLdM+2oFtul53LkvfGrLKd/nSyngKBKB9jnDQ4YQIRVfd9CLtSRM4PB
+        xtkWQPYI9NBIbDSXBtgZat/CmQKCBatzW26sOu0AnqJNFzVV7zag6E42hKYz
+        5nXmRf9fl43Mi2xnG3w+ZIvW6Cqvf4VsV8j23ZAtvjq/ubzZl/r4UfYb8vjJ
+        7RzA81KQbYbqtEO1kGg1yFYAjxzGFFkNJXZCsheMS6wByDCtMTFeafo+ef2I
+        AyUERSxgRi6hI0A7DQKuNd5oqByChltAs9FjhdH/AJqJM5IrjTAlXhlkiJNU
+        AsIQVQhZp8JnZNa1SRFkezrKnilUFMzmveQrMPsvA2YxZxSVDWYPD05f5s1D
+        WXW0uHfXmt4eHG3Tp5q/mBwe3w/97fLz5jPUpkSL8wWLgdmDeDCM9GgYXca9
+        bAi7RAls8DkSWgaxCq4RYIQ0VZAoS73yIvgkrIQWFKrlm8wsg5Vnr+d8WJmt
+        kRVWXmHlFVZ+3yna+TOilluOAsOfvi1HMeG5ZkUtvDRFhmdV3I8pd37akv2Y
+        8gejvaI0hYQLzVFbeEkKDJSr8M5k+nhfRxtx40adnK5v7J3unaGdZSHu5zuT
+        dNWpdyZFRKvpyOQIQkwhzKmQjmKNA9XEGkjLrADQBwjiiGMzKzWq68hEvQmI
+        SEogObJEY4x48KvMEU+1sIQEVGVl0gbmHZgl4AY5wQESGIGA0YTkBDpgPFEI
+        YACplJJ4k90tquQZ59EfX2ZkrPd67XEANqo//TIvY+lEsrx98g5Nm1bT9/Km
+        71U5CANv90eHJ8fiCtHjWnz5bMe722WFBtJ1p4YGCoh+tf5+R40G0YayrjNc
+        3vp5FqjU+qvATE5gZjUA9zvjrwbglkdsVgNwV4O4f4VB3NDx0XRjA59cPx6O
+        +0PNTnc2e91yrJ+hO5W7FBD9av3rcdzruaj59wBe++3w20pwRXl2qHYemKqx
+        nbOJG9z0MIuRPdiKRUk7IEN36kFcQPTrGlyqzrC0DZBngEo3wO6TvLsZtPaP
+        O7eb6807Fp+q3eeSNkC67tQNUED0GwNQ1kYNs9sbxtk3hnO8+zkmqPQYrh9P
+        6f7R0YlvNjZb6rm+f9cbXpZ0DKfrTj2GC4h+qyXptJ+VdsNWtNXumRIWIM8I
+        VS4AHwHYjXeux3eWHe/rztWzPx7E5SxAhu60BSgi+q1tcTKos9lVnY4rwfXn
+        WWDhZENKkKxqAD2regA9hLtXp7Z+194B+wei1yLb8I7b5e9n09Wm3M/mCxa7
+        nz2MJ9Gli9b7AbAF6jKjUIe8/tF8WYZL1c/MtPR8N6dyDfPVzenvd3O6ms/x
+        fWDhPedzwONbd328f3Itd+jD0872nqLt53IanmWoTgWURUSryTP0UlEJvTRM
+        MEyI1VxhTAm2WgFkwt8x1EqTGXmG+LtbjVLzDDUyUHtJqcYYCgs1J45ILhGx
+        zDHPJVHaO5l9G4QkL/hw8zc8c5AYpjEDiMGkgxOTUGPCmDVEIcK1IVRhOeM2
+        qFAFzV7AKYPkEuhY9e+jP0rsFJD36q+mcvwLTeVAgBNUdsvgRg1KTIAkVY+6
+        4+jibhiP9ls1rTbiDnJ8OFAnS+PbDLVvsU0BwcLV6l336T73+4398dsl7z++
+        3/P/+PCqPciMspsZOYs5gHiZJsCzV2a+eXVgDa8yCX9DPEyGNxN/2985Mrg7
+        frzu1K+b44t2eXg4Q386Hi4m/HVDbyo/jI5HvftysHC+KaqcpbFdE/d+2p4e
+        301b7vz8clq/Fsvesn2epZGuOu30LSRaUfNfZZLmvo5RYrwD2gZkDC21jEBC
+        uUtmG2HL2Zvuaj+l5gYz64AwxAhiFFSYCgUNZtpIy7gmUGhslMLZg/SqnKWh
+        ucVYcawlFdYgo0VCKljSbEsmc/4CpTAaLTtL4+z06HAtOnC3ymSGEguPy8h5
+        2d+he2/+3l8Y/RbwanM4wDz3t1ifppyvv/CQZ0Bg6ZU3l5sQAkqEqLpPE1U3
+        tcnZ7sA/jhF6oNpNTP82o2frHMg3Q+1bFFNAsBjy3XR99/zsbDaCJfL1j35e
+        4fhsE88LYQlZQdgVhF1B2BWEXUHYFYT9IrWCsG+faQVhC0NYyUXpwdsvEFay
+        iiEseLhoazQ8uD49a1xLqK4uh6POaGkIm6H2LYopIFgweNuPe5+3bvRHvWej
+        s/aw4wYLzlLOC8ouMwphtsnng7RwDYgVpP0NIe3tLT9pjA92drdo/WpzsnfC
+        BjeyREibrj8D0hYSfrVTVW/g4343vAyfOrI3TWlTEfINUyXA1WfDo/HBFdg5
+        Orx/ik+ecLvPy+mLlKE6FeAWEa0oX0EzCYiR1EFIObHGCQmZlCppluSlpyjg
+        N8rfZ0CbN5JLgyhw2AWw6JJ+Hl4aySigFikYPjEK0WwQWWVfJGqMwkTAYCIM
+        KUDcSm2MBdoZ6k2wp9YOIbwswC2w9RbBujnv/c/HunS3I67vRhfrl/eXhzvo
+        6fZuq/FQUk1Shu60rVhE9OviNIdu7KK9AHTi3uC+hHTcPCMs3C4JMc7LTse9
+        3ICAA8xg1ekKZEQu6p2nI77XILun5O6UnB3AwfK9P9PVvgU5BQSLId71fr89
+        Vp3oLI7qYcVb2UiXLT7tmBguACOOGczlS2tkL5ChgDvhOSHeOC0hN/p9px3P
+        XtP5IDVaQerfElKvEn9/ncRfZif76/vg2A9uDi87vsXk0dF4UgqQzlCddnoX
+        Eq0GSGutNJJQCYChSHJscUDTzGvJEUCCK6c5hwrOCnhWB6QNDn6dUYKgUpQw
+        JYO/91YqigmUzHlnvTYUZaP8KoF0APhCC2+sI5poGBC+C4/EqATYcMUFdV5h
+        vmwbmOZQ9aNL1R9ETdV9mFG6WRRC573xq3zfXzHft8pi/unTdG+wpXr19dGk
+        2aD3R6ObfVMSg0nXncpgCoi+auDZs3Evak67D624Ny2zr0KeORaO3gskS+cy
+        zUaS1wIFpFVzmQe/B4FjEoqtjevm5Eo/nHYyhifMw2XS1aZwmXzBX2FuNEM7
+        1/yCtk73h373ho9q14/Xj6Pl9tJnU2WoToUTBUTnnxud991S50YnkZ/d7oPr
+        J/3JGips0y857v/4drR9ChDVuw/tZAjmsN++d0m7JnM/a0YbXXy89FJNc2fv
+        hPkYIF7Dqzyh35ABogZxh7XxBa7tnQ8manzfWj+5ReUxwAz96QywmPCrQv5u
+        2J2HbjIMB/CnAanl8MB8o1TJAw/4znrzcbsZCMV4eLSjL3v7l8u2FPnMA9NV
+        pzruIqLV8EBqHKPMKIigw5ZAqiTCSYCNGE8AxZQDjoWbdS9Q4Qg1yGHgp0YY
+        qBmQXHDtCNVYM0RNMoTCSBYo4ruMmeaB+FmkjVSIhT8RrjHj3BunGLbOaBw+
+        VJIsO2Z6oxPHNtoMdCNA358yQjpvS/x8oljAQyzMVAp4wTkcZnF3uRBHyTPE
+        whyFCgbL5ii4QQHjAiBQdXno5pHauq3p+lZ9H+62jzcPmwibpTlKhtq3+KeA
+        4K/AUXjjZv24BclTv3PLxAEb7Bya6XEpHCVDddomKiI6P0fJ+26pHOVTMGEG
+        03hdNjIn03j9T+cuqp35Ps/LNChbMY3fj2ms0rdW6Vur9K05H26VvrVK34pS
+        nmlO3/jbp29BikH5BQuf07dA5d0UWyeN54srG2/eXJkjyLaPWpcm455lnm6K
+        6WrfgpwCggXTt0bDWMfDwQyEu/ikO6GcAVqxZAYokF46iQCGRCGkgAKUOqwQ
+        FM4vn7a1BJKevZTzIWmyhtAKSf9+SHqVtfULZW0d7u9sPUG7sd/fOGfidHMr
+        5syXE61PV50arS8iWgQ/BwQ8Jwxk2FulAIfaB9AXnK3W2GnFNYRCOKmQoFop
+        +YZbLTK8i807vAuFM0FZKi3m2FqWFCJb4zXlHADFw3NTw72SZdT3Uj7nswlh
+        sKPGYoClg8R55ATgxnjGbDCaVz6cUdQum7W127Nt1VPRXtxzg0j1bDQMGHq/
+        3bu1cTeK/ctfa/3pYKg6UfN+1OlEf+z2XvZHgp/Ch3tu4jrLx/BzNsoq2etX
+        TPZatFoC0IC9SobbNXIKBGRcVA63r6/39y8J6MVPe2LjcONos9dvZ5SxzwO3
+        09WmwO18wV8heg+a9cdz1N0Zj+9OH6R53jkYwm1SSvQ+Q3Xa9ikiOn/0Pu+7
+        pUbvT1XbBoz7Kbkom+KQJTrFL8M8Zr7V8zEPuoblinmsmMeKebwf8yAHvve8
+        PnoaDbqDutqrSb97u9crhXlkqE5zv4VEi40Nnpd5UE4VodpBQbzlSBpLLNBe
+        OqME0NBoKon06E3+2EJjg+dF95o66ZhRBjiFDMMO6fCUTFpHwwMj77zA1us3
+        r+sikXs857MJzHx4KiusN4KIwIC0BFiFj52TQBkHFGbCkiWZRzMZ+HgbHScV
+        m0MXnU5VL/rjh/nBPyF5KG+frIjHvxDxIJxJ/HqcThnEY/MSSgEIA7Ji4kHh
+        9u1DH/SvMT0ToHYidiYnsL58b810tW+BUAHBwl3lowM1GEYbajjsuOhjlOIM
+        /vy2yaOLgNDaszJf0OKg+XUXz7lbcc5ckXlBM111k1+B5hVofs9w/Vnz7uZO
+        aNLYvlW3T/VLQludvXLC9emqU8P1RUSrSXeBSmPjWYCgGgLAgWHJhCUmtfOY
+        OOCFpAJjlJ2/zrAoiEvnT3ehGknqtFXEMqyZcJZIxSlzgkHoAOEBoRqAs1NK
+        kJRFQfO8bAMrxDA22BIOlCcysI/wPER4DT1yxjhpvCdqFtsoBJpNq92zwS/+
+        xyA6CNul1AFLeW//Cgr/ilC4ytnRrd1tuXV1e3fydCb8vro2bkuvlzQ7Ol13
+        agy3gOi3C63hc0vdR8eu3+mq3vL2z7NBpfbfR7hzglrNk/XOU7PubgDVd7sl
+        2T9dd6r9C4h+K/+JB8OKCt7zzLH4LF0KWdkTFz7NGoMSVc0K8eZz4wzinb0L
+        Xh/oC314c7N3s/yssQy1b5F+AcG5Z439eMzNSAgT73JbMtvo8xE/tgbwivit
+        iN+K+L0f8cNPLpZoel+7vvQOo0Eb77LncuYwZKhOxZlFRKshfgwrICQhxjIT
+        2IsESDNpuRVICAsFFdYjz3gZtyXzEz/uKcUUY6I4h1oJJTQkXkIdPheQAk6U
+        glq/S50D5Q4LgR3iFhvqocLKEeCho5QgaQD1GCeJbksSv+82XPQx2u47NQy4
+        KtppDwcRlEx+hPKHNLoFKGDePlhRwN+MAvLarqnvHrUv1Y2p72BqHgb25rEc
+        82foTjN/EdEfKchx/DAok37kmWIm/XjdA+hH+iEJxBX025ISSMGrrmVnW0+1
+        4/GTOBp35ZTzzSM2Hk2XLz7JUPsWbxYQ/BWy4Vi7O+pf8VvSmd6cPo39dLM9
+        nj6U028rXXVqZLmA6AL9tnK+W2o2XEO1e58GkkSJ7aOdOJC/9U7cc9Ef//jQ
+        DH+btFzfRUGqMY0arhv3p//48J/h6LuI28ZlM8JZ+XM5JULcOunCmZ1kXgBq
+        JLLCcOSQsIg55ZP+KUQZCpcuEVrmznH2hpuPeoo1AFbU8/ejntwM14/OO7vr
+        Az4dNY42L+toa/pcHvXM0J9OPYsJfw+uNlS/Py2Hd+bb4i1fKLvJGm6o7cc9
+        cdibPPjO5OhonbYn5a1Ghv701Sgm/M2Nx73hNDqM+z8G2xdej3xrVL4eHE1v
+        Y+rH0lwP2rUDcwF2LspsepeuP2M9Cgl/w76BdUS1sChv5mcuuBq5tqgwKgMp
+        YccNJlG8cdm72G5sPu9JVs51fIbqNNBUSLSi6ZjcKsEVJ0gAEcBIwBsaO0mk
+        FTqpV6bKccYN/HExf0pUBnBOtGRKyIB6NAKIoPBMgFrMiLKeOEiSymr2HlEZ
+        oy1XxIDwhMhajynySRRGWo2MkkIzoawMvGvZqMxLz7SNpNFdLe50nBnGS7c9
+        z3vp36ObXb5HXjQGUOC4meNkKnAuLdjGbrYFFp/1Lhkrt+/E1umNgBABCWDV
+        1B8IRY9q2xuPXj7uXl/dNB42D0Z3yw/KTFf7Fu8XECx28/hqG79cQmaTSzjj
+        ujGHXELotTFMhv9wqSUyyDGLoFBJeS8NvgoA5YAx79p/YvaSzksuMV+Ry9+P
+        XIKDqT+53DtjvSvlD45vHp+cPPLlwecM/enwuZjwV09wEXZ6PBpE65+tVQqG
+        zjdIlXVgzMT4emu4eX45eYSbbRVewp0lm2h+qQNLV512dhcSLYSh52+ShjzV
+        TAPqsOZcEIKS/ykMBeTeQEwCjAaeiGwoWBimLtAvGgCkNHLh91NCDUUMQC4p
+        h4Boxj20iBOl+ZtWgj8DQ3sODIFWa+ug9gpSFKwFLcAOYoYoNVBiT+CyHdyO
+        2/3kJjM68i8lX7WwA7V2qvet+OtbiuvSxV45m+HnY2uAt/ujw5NjcYXocS2+
+        fLbj3e2bklL80nWn7c8iol9XbL+jRsnYC+s6w+WxdZ4FFsXWEpAqZtADjILP
+        yBgoU94Um/VNZIOu3fO7wyE82DrclRvj9vJTbNLVvkU7BQSLQesd9x+DSEWf
+        Nnk2rmaLz0iBr1vCzT0jZaad58C7cA2AVR7fb4l3cX19Zwvf2d7Ojr2P6eZG
+        v3V6flwe3s3Qn453iwl/f5lyHE9cp1NSFl+uMSrEury2Y6f7D9OTydPpxfpp
+        b50iPK2VgnUzVKedpYVEq4kXWwihVkpQTKULuFVZxY2k1ELqsVCAYMmSEq53
+        iRcj5niA3JCJACJtgOPcWymcpzZgYEO8tR4ChEvpeTAv1pUsQFqEQBLJVpYl
+        7ZSNZUgbzIn0xkGHCKF4Rt1bsdko8ajfc9Gudb1hcvItCWfz3vd3yNbL3/4L
+        w9kCrm0OL5jvAxfL1csxwOI1KqVHij8NPEGYcVA1nOXkgIPTm/vjjcbldNrc
+        OHg+Mwfj5QeepKt9C2YKCH4PZ3+0aEra0owuxcXHcPST3MS2SRb6rYH7Tg3i
+        3suv7ar+vRumG6zM+O/shZoXD9PVzMD3wcODdu+2494NEB8NTtf3a+N7zJ8n
+        16b3fOrp1VaJgDhdfwYgLiT86t5Ql5RXlG+FKutZNh5lvN84Hx239k+v+R6p
+        nZycLJs1/7meJV116jFcRLSizAlJeJJ+AA3BAjADKdQeaYgEhVZDbBXl0s9I
+        Tqh0Wjzw3EFJnQvoXDOqJXHKGO4kYE4RLShTRGH6HkhYO8gko9ar4K4RCbA4
+        gefQaUuV4Ax5wSHjKhulF0PC9adhPyn3vFTTQfTHJ1ycFHu6W2WmS3cyyHv9
+        3wEY53uDxYFxvoubwxvO8IWLIeKcb74wIpZAlBzg3d7A65sQBRYKqs6dwAz2
+        2fY+8N6dPJ3e1W96rH97sXzVdrrat3CmgOCvUDaBd4ZH/fWhHcihno5O1fRK
+        jBtLZgB+MVW66tRdU0B0/rKJvO+WWjYx229GH7/dmuX3THu9uebMZdGUYawA
+        VEyxJGKivHICOEqgJ84S7A0Xnuh3zWWZvcXm4zJoDa6mEv6GsX36uHFTPxtO
+        n/117+oo1ptXums2y6MyGfrTqUwx4a+uYlP1etOo3vGlpebnW6PKRJYd8zC9
+        P9s6FTd+Ou0fXcm7w724nESWdNVpR0Eh0WooDeDJNBABAfXOK2I8pRYEv+oR
+        USQpUUMEQo6zq+CrpDSKCo6AVMSBwGOA9MI64jRR2kpkrdGYGa7Bu5Toa4u4
+        JuGscd4KJbCmSAT7Ga0N1QgJzAVEzJolKc16QJ8u2u1Fl3HPun5H9TIHaBfO
+        V8l5599hDGG+C1iYxxTwb3O4wgKOcLEZhDkWWHwoCkdVJKxAgDlHvOqhKLDT
+        Xnd4a9zYHjzsySes4NMkYyLGPENR0tW+hTQFBAvOIEx2cUDUOYng5H36Ts02
+        87yYFq8w7W+IaVd9p76PT71n3yl4fOuuj/dPruUOfXja2d5TtP18XU6FY7rq
+        tNO0kGhF87WlohJ6aZhgmCTNhhXGlGCrFUAm/B1DrTSZgc3wd+CsVFCrkYHa
+        S0o1xlBYqDlxRHKJiGWOeS4DvPVOZlcRIsmrArXKQWKYTsYLs4D6MWASakxY
+        wLFEIcK1IVRhOWM+IC4CavcCSBkkMzmOVf++1G7Dea/+qtXUr9hqatFgPaCC
+        VNBiFYT/ScGqTl8B1826vOg0axejJjw+Xx8fiIur5dNX0tW+xTYFBIuB23pS
+        qNx3NukZ9zH6bm/PNW6DzAgd56Hf1xRn7vSUmQsxH/zFa4iu4O/vB39hXdDJ
+        6WDQv706apzfdjeOOg8TVh78zdCfDn+LCX9r/59eCbUw9s23RZXY1zwcHnJ9
+        H9eQaI0HT5P6Vm/vqRzsm646FfsWEa0G+2KnBaeGM0mcEIBbKoHHzFPHksl0
+        2hrrDIGzWodWF9DFgFDhJWFIewCI1IQDZj00UDCHnAWYOuHxu1QmGi2CvTxM
+        7hMDFtfQIqFhgL9SGm9AgOtQOTEDlxcL6O6PerfR1igcjz2b2T+yMNzNedvf
+        ofTwugYlMsd4/7h2evkknvui4csqPUzXnbYBi4h+KydTvUF00+52XWaflTkq
+        D3MMUGVf1VWifEWJ8hBhCsoOo583OBAQEYSrHvHnH9jd1fZg7+bcmeF0iz0c
+        gfr28iP+0tW+hZEFBH+FtCC+d12Xx3e9/RO76egZrQuP8H0paUEZqtM2TxHR
+        +dOC8r5balrQUXw7UdNofWBcz86oTCCvh1/+ROI2+72el7iRVV+Z35C4gat7
+        SO929jtTYvB667hPx3fxennELUN/OnErJvzqVlH1oma7M36p9ymHvOXbo0Ly
+        hvq7z7tNs75x8xTfd+lzK47jJ1AKectQneaBC4lWNDBDWOi01owbhJHFCBLo
+        AXVIYYmhU0oSrSyflSdfHXkLD6KV4Tg8ojBOMZ80vAncMnyAPFZWYs2Ft+9S
+        aktZoLSGUYO4JZIp4KUyDmPCHFAccw2FYwAtO1486SWzPna92+B+l+VueS/7
+        O3C3/L2/OHfLd21zeMFCPnAx+pZjgyUYBC59HNzOKXzRyzJyYspLxKlfbo+2
+        tu8O74/J/tPpUzO+bPvG8ok46Wrf4pkCgsWHhKds4B/nv70enDEnoH2dwjN3
+        Is5MM88HaMkaWjWOWQHaFaBdAdoVoF0B2hWgXQHacgEtl7z0AWNfAG31A8YO
+        267mphvEde4ofVy/uW7vtjPS2eeZmpWu9i2eKSBYMLO832+PVScby+LXEdaf
+        l1M+28DzQlm6Gii1grIrKPuuUPZMrp/ddq+uNtHumdKT4e7egcXlQNl01alQ
+        tohoNVAWegEQtlYpJLHDmlmNiLEQUGko8yAgRQ6wfJ9hxtorAzRmwhFrsNQK
+        CY4Id8AFBOuJY5wHKEneJbEGcEIFN0oBGeynOcWIYou5MUpbrz2FiEFIlm2D
+        WFMPw6SP2nrX9dtGrb00/t5q9wfDLwg3+uNrH4NGnECZ6LhthqO+i0rMQM/b
+        JysU/K+EgilDoOyoblJeCSkPqqvOC7kxZLTd3a+f4G0wru03t+Dl5WD5vJB0
+        tW+RUAHBYiD4h60fFeqniN6n2HK20ecGxnIFjFfAeAWMV8B4BYxXwHgFjFfA
+        +BcBxkxU03ckAGPGKh+UIxhsNc7tabe/d75+jh5uTo7PMsoq5hmUk672LRIq
+        ILgQMK4kSoyWGpUz09LzoWG2huAKDf9+aBi2avfNPXN1Wm/1Y+t2d06sGosS
+        ay/T9aej4WLCXzfoqeqG7bl5pybKlgSG881RIRgGd6fo/unEHF7Z2u7TuHXR
+        vGoNlqyh+AyGM1SnnqhFRCsaluMQAlwjkZxT1EJkiFFceYUUtFhSIQj31Gfj
+        zSrBMKVMQiUJQUY5gqkiQhnqPRTheT0h2jGjsM8GnFX206MYAitJ0gocCoUB
+        BMxpFE58J5GwVBPDLUWzWEQRMLzbD+i2kd2yrSiazXvRfz6aLbDvF0azBbza
+        HA6wiPtbCMzmmWDhXAcheenlf7V9DETSFLzyOTmNHjq+bG333CW837u+vHyc
+        nFxvLY1mM9S+RTIFBIuh2c1+e9zu3UaX7WHrhcSexQ/RZjyZ0VMEvwan87Wj
+        JuxlshmkABOtUPCWklCHNKYYUyaEhhJpr/G7tqOevbbz4WexRsUKP/+G+NkM
+        Nm7PCDokD8fHA7iz13q62t0vET+n68/Az4WEX+Uvxl01iA7dpLR+1PnmqHLY
+        5LgGp/7wypyftgi6OeTgCRzdlTNsMl112hleSLQQfsbzwkCBrROccm1FOHWp
+        dsoL5YAFPHhXyBn0DhviZrVVLgpRkeRzPpzmFkOcJCgiTbkSRGnMODcEKEK1
+        gB4jRZjPfrg58DOe89lgwPJAE4WMD3BZasN5OLI4pJprDTVjCjOi2SziUQQ/
+        f44k9aINp0bDaanN+/Je/nfA1Pm+YHFMne/p5nCKRVziYpg6xwSLY2pefkHc
+        5iUMeBoAUHln6h0j+37rdHBeF73p/mZvenXL/fIFcelq36KbAoIF84e/388z
+        auLI6x/NFSFeqiRupqHnArgQrErifk+A+3y/97R11z+Cvi6GbtqPSQ3vlghw
+        0/VnANxCwq/GDIzbNtobdaal4dtca1Q5b2WDNaYDLcTjgYwJbsfT5+1WOckS
+        GarTztNCooXw7dwhWMIoNIwl078Z98gCRWkSNyDIa4FF+FwmffBmdFguDCEX
+        aM8nDAqQ21kPGIYgQNmXsZYOGkCwCM8YYC8R+l3mrSjIhZKcWUAt555S4RLc
+        DaDwkhNmtFfYYjNr9mYRfJuElY6TAcrtW7csns172d8Bz+bv/cXxbL5jm8MH
+        FvCAi8HZHAssDGcBQKX3ot45hYChZAJT1SHi3cNHWuP1g9r2w3gin3bcVj0r
+        y2KeEHG62pQQcb5g8f4OKdv3BywLl6iJe93rbO5o7Uwzzwdmk/TfFZj9/cAs
+        bdYvARkeNhr9o2d+vnWyt87GzyUOD0zXnw5miwl/a7Tqev1ptBfMXt70wFxz
+        VNlsmtxNDsa6u2UZuB3WmuaBPhhTTrPpdNWpp2kR0YqaTWvqqSUcGUW1gggA
+        CjFDhEEipTaCEmigfKdsByeBlIYFdBiekDvHHdIcOOmkUdxyohBXlNF3QbPh
+        wRQGFAR4rXV4OkCVSjplBDrgNDKOSUMg1cum/l59bNQP16Kt3dPmWVQ7WG82
+        l8W0ea/8OwwPzPcAC2PaAv5tDldYxBEuNj0wxwSLD1gB5WfxbjUkTNAyplWX
+        t+1edm0H48PDs4PBfufgjF02O63ly9vS1b7FNAUEi4HaT7n6tY4azOpZtvjg
+        7WTIqyPOSaiDs3TMUIYJUwY6BhGEhFviicH2XTMdZq/mvNiZohV2/g2x825H
+        XN+NLtYv7y8Pd9DT7d1W42GrROycrj8DOxcS/jalZejGLhwZuhP3BvfTktBz
+        rkGqzHVoNG83xluSNm+3x/uD67pvTtxhObkO6arTzu1CotWgZ2QhM0oypxUK
+        ntcFJ+uxBARihSnikDLDlBezQGCF6JkgQK0Ofj8AeMvCs2DnmYPIGUOwC08I
+        IfL6XQrnlHRAIg8DThaScEeBlzQ8oxVMEYa4cQZoRJfNdThOSmf+PdpO/vNH
+        Y5QMNdvqx92X1MPv6+SWT33I2QvvAKvzXcPisDrf9c3hJYv5yMWAdY4RFu8G
+        jIAoO1qMG4F8Q4lB1X0jkOg+PLb0w7E5rN3c1c4Pkaw/3SwNrDPUvgU8BQR/
+        hXkiZO/2dvJUq6v7i1O1vnl4uHk1QUtO/vxSSZiuOvWus4Do/PNE8r5b6jyR
+        5qgXbU+72RwGLT4BEi1BLWa/z/NRC7QGV3NEfkNqAYHcGuve5sWhuoXnZm/z
+        4mGr0y+PWmToT6cWxYS/7suNflv1orPp9yv9/WrPl2KSa4wKaQV+Ptu708hs
+        XfCrm/un5u0RORl0S6EVGarT3G4h0WpohaQKJpF3wTBjUCUpy9h7pBVUBmol
+        dfiPomRWpkR1tMIIChnAnmObFEYSpKQySiuFAJdWe+s4odpn579USCs8F0gj
+        l8SyXPDbDmEvOGKGG6ooAoZZhzWQs5pVF6EVX0oQI7wsa8h71d8hwSR/5y/M
+        Ggp4tTkcYL77Wyy/JMcACzMGggmtot0yxoSwqtst8zp9gjv2dut0Wut1TmO1
+        3rjGYmnGkKH2LY4pIFgsFJ+6d38chycXRrFLlQLOtPG8KHY1xnyFYlco9v1Q
+        LLJn9auHQ+5vpdk73q/Vppt7cFpOV7l01WnnaCHRalCsDj6HQipwgIfCYyWo
+        dVBxhwniVBsrXfiJUO80OYRRKaAAxEFGsaIWEC4VxYAy7mF4UCwpI+hdGmmo
+        ZNg7wpprTwTTkgioA6RWNnyGlXcAQBrYgFw6UTruf2olt6n699Fl3O/Yn9NH
+        LmdnrEDvvw7oxUDC12iqPNBLUfXtlfsn3dHh6d3+GRtivNc53NOG7S4NejPU
+        voU9BQSLJlW/3eoz4O879VWeae354C9eIyv4+zvC30uCTHzidztDpoe3jw9+
+        7/L6pET4m64/A/4WEn51WT3st819tBkHn14SAM41R5Vh3KNaU8XrT2jX3rvz
+        oSVn1Iya5YRx01WnhnGLiFaUWw2JEoIZzwnTgAGCqLFCmoDnlHTIa+uZ4KiM
+        ThjzA2AJEJCGYkox0hQAZ1zwkQIhKAnR2DrDCCTiTePDnwGACSaEGgA9cRop
+        6pX1XkIrHKOceosxtFJ7hEsAwNFR82zpIG7Oi/4OeDZ/3y+OZ/O92hwOsIj7
+        WwzR5phg8TJBwUrPqD6FGxAiWH0Yl9n+loN3dw+P94f12jFpIHcyzGh6OM/U
+        vHS1b5FMAcFiiLYZ9wbRkY+ObHtG8ziy+Bjo1/9y7tF5M608L5Jd9XRbIdkV
+        kl0h2RWSXSHZFZJdIdnSkCzFkJedkPAFyYqqY7Ow3rvGyMU7p0fi4rB/vdPt
+        6q3z5fu3pat9i2QKCBZDsvWwzK3oLI7WB7eqPyMsixcHs+h167e5G7jNtPR8
+        aJasYbZCs78fml31vPh1el7w0ahd606298lkm23u3oCznYu7UTlVe+mq007U
+        QqJVpddaCqQABlPBlAPAKou4t4hiBxLwaBhGZgZgrBLNMkQkUEYy4TzByhEE
+        EVBQSqCV0goCpa0LEPw90CzkkBkmAvIHBIOAazHEJqBZAJMiciE18EoJQ5dE
+        s6nj7i7bvbADombcse2fNO8ub6OsOmX8C3XKoAKKStJzCaaEVI2G+e20bgbk
+        ps3knW3sdh67g+dBRvXpPOm56WrfIqECgr/OvDu4TDvj2ZaeFw3TVTvjFRpe
+        oeEVGl6h4RUaXqHhFRr+RdBweLeDN6gKDVfdDBnqphuedW9u6bFutp4O7odY
+        rz8uHxtOV5sSG84XLBgb7tko9tEw7PiDdm9GP+QlYsNL9UOeben50DBdQ6t+
+        yCs0vELD74iG0clzjepW/yZu8c3nTVK/j41fL6doLV112olaSLQaNEwk1UR6
+        wALCJAhhrgilhklNnaBIK+fD+cXQrNqr6tCwYt5Yp4y3mHnLmVCaMe61xUAQ
+        5ajVDCd1Yu+Chj0iFAkkMCKaKi2RwsZ5ZMITWuRwMv+PCLHs9OcvaPi41e50
+        2g+Dn1OwlrMrVtD3Xwn6SlR+n4aXzm4IMcgqhr54t9557t2d38W1i8m6Hqyz
+        u4nJaOs1B/TNUPsW9hQQ/BU6u6F6F2EVH7EuP3s6rN3z/Xjy6Erp7JahOvWc
+        KyA6f2e3vO+W3tlNeRcdxpMZudSvG7TNSTFeM8l5KcbsN7ooxUBnAK5hFFjG
+        imL8fhQDHEz9yeXeGetdKX9wfPP45OSRL49iZOhPpxjFhL/uzIuwA+PRIFr/
+        bK1SSEa+QSokGaDL7c0J6x0c3m3uctHa6D5sw4NSSEaG6jTnW0i0GpJhlSKS
+        EM+TVhPMASkxB94kk02Ek1YCTATSUr0LycDIAUA5c4gS5XkSYwcCM6aBEE7o
+        AGFcIBz2Xfq7EcCwsCShQEpaKpXUWBr+8l9EHAhWE8L4ZUPuJyPXGwaScab6
+        KvlD/H//9/8ziDbvVO82js57phUYiLNRPvNYlnjk7ZSfTzxIe4r3+ludjYOd
+        4/HV4yE8MidNWA7xyNCdtnmLiH5dzoNRexBtqHCexePleUeeBX544Uu1PnO1
+        28FIMljr7PB9dtgcXKmNVjnWz9CdZv0iol+tfxqb+2l0Ggcs+MPptZD580yw
+        +I0HZrJs2ne+DWGAoBjLimkfAGJyNa5djMSlGNf0I7042ezUlqZ9GWrfQtEC
+        gsVuPD452RksZPHeJMs0mJ5t3zlICF6jSVHnioT8fiSE+/WNZtxvnO30LrZ7
+        T6e76+SxOyqPhGToTychxYRfOXEdNYeq34/+/SX/YCfudKaTOLZRs927DW9I
+        pHoJIDItNwirUw5JyTdYlSTlRB88d/WVHj3tHajD2nV7KEe+HJKSrjqVpBQR
+        rYakMOmA5cZbSLEzUCKDFZLOhE+VQ14q5wAzmLwLSUECIAAw1F6jwJ6ggEAq
+        DL2C1ibDxCWBMKm1fA+SAogBSjBPoZXScq04tdgj4SUUymtPPUcS8FnFskVI
+        SrINN8JuSxIEdlRvEN20u93sXnCFKUfOe//zKUcBN7Aw6C3gBufwmOX4y4Vg
+        cZ6RFh4gCQUq+TbkrLa+cQwxBVhUnQhE7oA5vrs8Hj/b8R3use2r0Vln+ano
+        GWrfgqMCgsWnoidEKvoYNVS7N2y57oxsoO/KPeebJOkQEgJ5ArCB2KlkshnQ
+        mnEDLIFKIxy8vnbALD9JcpkGK7PXtRAcl0naEWRrSK6hVUnqbwjHyb5sNWvd
+        y7Y83/TgsPV8hmv9RnlwPEN/OhwvJvydOwj4JzrvDAPmGCbD7MLufRV4TA6d
+        rivpsiDfUlXicHWxd3cfTx73j04f6v3ale3VaEmXBemqU3F4EdFqcDhFQFsr
+        tIQAKWKhJ8YgjiglMoBJr4UVgmE7K7GmOhxuEziLDKGIQe0YhFCHJzQEWGix
+        UYp6K6x02elSFeJwZymFjgJhDAiA22mGsSdKWMUAZck9i9BO4eV7ryywFxcB
+        5jkb4ecDc3bR6PRPxrDXezweHiJL78GtvigpGp2uOzUaXUD02yRu1RuqwfTT
+        Ig2i//u//0+07ALOEbvOMdjisWuKSbnZ+lun4DJsZ4Rh5bWrrBuLjdb53WgC
+        xfPt5vEJ716cL99lO0PtW8hUQLAYSD/v6b5T94lY9MenlygB659en//Mhutw
+        RvJ+DlwHFmnjfDIylzrppRBcMMmMM9L74IAZAs4JXcLgd7RMa+/ZS1wEr0P4
+        EZEzKNcIWCOrhoi/IV7ndv/07GJwtOvQXkNNrqfDwcMGKDF8nq4/I3xeSPir
+        ZzhUw5bqRVuj/lvQvWBsPNcaVWLy58ZA1CYt29Ln49oe7j887B3Wy8Hk6apT
+        MXkR0WowOdeCWsyNd9gZRoMfFSKJlQjNkIDKSEpZkkX8LphcepTU7HpJnQYK
+        SEyMCj4SGc441eG5lQtHBMieHlkhJpdaBAthSRiwTrhAGwiBkieBcYGoBVRY
+        TyTPructhskPnbPRVtyPmg/Jn35GjUDenniHuHm+i1g8bp7v/+ZwlQUc5WJB
+        8RwLLD7KUZJKhr+TQOxB1UFx2tjbP1VXj/J5eFl7kFvrVxN6mdHkc56pNulq
+        30KeAoK/QokAa1yo55urzUNuGvZ+LI8vBjs9UkqJQIbqVHJbQHT+EoG875Za
+        ItBQ/UFLdV6caNwfZPMZ/Hpr/MT5QTPf63ySQT8C+hGxM8ATkgFWtci/Icmg
+        g/Fmz4q7eKulH/Q6Xu+Dmj8sj2Rk6E8nGcWEv+7PvVHvvu2iq4NyGEa+KSpk
+        GPRxsmnG9uL6aWMEmxfPV3ALKlwKw8hQneZ8C4lWlH2DgHSYaxiAsqABFlhO
+        BcKUSOeUpkBpb73S2aW+lXbl0ZYiKHRSIkCMQ9o7ooRXDFOMwodaY8cxy07D
+        r7IOGXAjlHBEI8aIFMwwxqin2NnkloJajQJvU8uWCDSUjRrqaS2Bqkl2c/jr
+        x59QEJC3L96hEjnfTSzMMgo4wDl8ZZ6nXKwKOefrL5x3wxD8rk9hGRTj8OAU
+        UgCAyBjcXl47yp07tMng7rE63q3Z7Y2rrTtglm/OnqH2LeApIFgspL/Rj4et
+        JF1rtxet97szQO+smfE5QXwjvU7CIFhoLaUBKjhXS6kgUjroPYPMM+mkXj6I
+        /xqYz934cuaa5sNrlqTAY5DE8CldQ3IFr1fwegWv3wdeQxAf8dFuiz9B0FBc
+        PeO9m41BKfA6Q3XamV1ItKLZ9MhoBZ2hAckCpBkUBCiGKBYSK4IIRMH5CpEd
+        I6+0ApeLAKclA8R6AxEPsJUx6AlhlCdjjQL+50j57NuFCuE1x9hrKwXynkul
+        Xi4aVDiSGArGQ1QKK7wlZtkA/qZT9iGOOz8ldJ+3G1ag+l8EVEMkACg7bk8l
+        gQQwAKuO27MjAHfQ9ZZ52rnpywm72hw8XWVUZswTjE5X+xbmFBD8FeL2AE3O
+        /fXFWQPfti8euhc75EjvsFLi9hmqUy+nC4jOH7fP+24ZcfundnfUjerex/1h
+        NoPBr3fOfAxGgeTAElwzLB13EgMoIJZeSM00wgpBDRzQYGkGs0wN7+z985nA
+        fPEs4W3tfvIL8IvH+NALb2nyybc7jA+x9wP38uEXoReTxKPBD4LDePgJxlP+
+        b5/X6dsXSDZN54tznEkR1r6IrgEw2TFnh+D5pD3qkad+Wz50x1cf/u2f/z8A
+        AAD//wMAiZBF5njSAgA=
+    http_version:
+  recorded_at: Sat, 04 Nov 2017 12:38:23 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/track_find_3jfr0TF6DQcOLat8gGn7E2_market_ES.yml
+++ b/spec/vcr_cassettes/track_find_3jfr0TF6DQcOLat8gGn7E2_market_ES.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.spotify.com/v1/tracks/3jfr0TF6DQcOLat8gGn7E2?market=ES
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      accept:
+      - "*/*; q=0.5, application/xml"
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - Bearer BQBDc05mz_jClPPRwA9hC1V6QL3DqmxlzH6dvyT_SbzXP1UEdcXz89W5iNSXoerCBfMqDbx0qhqIIF2_-7JDcQ
+      user-agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - nginx
+      date:
+      - Thu, 28 Sep 2017 09:37:28 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      keep-alive:
+      - timeout=600
+      cache-control:
+      - public, max-age=7200
+      access-control-allow-origin:
+      - "*"
+      access-control-allow-methods:
+      - GET, POST, OPTIONS, PUT, DELETE
+      access-control-allow-credentials:
+      - 'true'
+      access-control-max-age:
+      - '604800'
+      access-control-allow-headers:
+      - Accept, Authorization, Origin, Content-Type
+      content-encoding:
+      - gzip
+      x-content-type-options:
+      - nosniff
+      strict-transport-security:
+      - max-age=31536000;
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAKRV2U7bQBR971dYeaZ47PEaqUJlDQUEVaGlqqpo1mQab4zH
+        hAjx73XGk4QlTox49L1X516fc3z8+MmyeijBVdqz+tZj/bR4HqpZweZF094x
+        PalEqcp544+Zr6vsQTGZoWRYyaRcIeleWeRK8JmGGitVlH3bzguW7ZrGLslT
+        u4G1w/MsAsnNj2DAQHh7PziN7u4Gg54Be9pZ7BtLxl8AokK8wLt3DGTZhrnE
+        ElQjbRvLUNrQ8VUSJYh1kWcTNitXAyu+9OJVo5JC1819/abf3/SuT9Zfw3cr
+        sx15nWtn+/jGuT37/TAYH02rSZJcu+BBTcwqs6gTpXO0sg3OABk+twylaMRe
+        u2jMxGis5sXAA8/oS17cVV9FaFafZGsQ24sCGDsY+DDyuOvGMfIIcHCIaUR9
+        HPk+dwFlPF4JMhVUjc0aw8G6IyDofoQDSIi9EPgAupjEMUUuhS4jbug7CENO
+        aeAR5PM1R9RrNhwReN1vCLjv4IgHmPgeQJHncRaHxHUiFGCIQ+Jwj8dxtJaI
+        V7Zbuf1iIdn6PHhj7nmz3244bbd1KfJhp29PkHdZvUt6dMqOLcnRkhvvTw0j
+        Xo+KkgyzKsVMzgGcplhJpESeDVNNrRu6MNbOqmkvEkGENhtHSclM1Ygh6DMt
+        eqKURF91sn9wdO7U1oWBu5K1RcJuAiqJyMT2j3/S4OxWji7jffjtKj2ILq9q
+        UpYruminkco2KA2zCKlNI+WwSNAM4UTLo2TVUJOIWj465DJ//s/8oHubl4f/
+        uATXx8Hhd3J5jlQ0OsnCI/f95jUEtMC99O7moaU5NWSbN3Wz3359I93yOzjM
+        rVPrF8oyZJ1l+XSv4bvIiypBUihNVdT4tpDsXrDp8HX2FcvsSwv42UzZIWQA
+        IID8mERxiJ2AAs4goNyDPEQM1z+HEIQx3SOCfvERcUid04hC30MMIQdRN4gh
+        hRDjOCLNVfrV3nxOa2hpIaXNz0//AQAA//8DAERuxV96CQAA
+    http_version: '1.1'
+  recorded_at: Thu, 28 Sep 2017 09:37:28 GMT
+recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/track_find_4oI9kesyxHUr8fqiLd6uO9_market_ES.yml
+++ b/spec/vcr_cassettes/track_find_4oI9kesyxHUr8fqiLd6uO9_market_ES.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.spotify.com/v1/tracks?ids=4oI9kesyxHUr8fqiLd6uO9&market=ES
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      accept:
+      - "*/*; q=0.5, application/xml"
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - Bearer BQAWAI90GvKiMNCp1pHz4sfHGdnqDt_2IBDycfd8DMd6g2o2aluxSaWScHaUp_tvsrV1zRJyZ6RVDkUEKgZk4g
+      user-agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - nginx
+      date:
+      - Thu, 28 Sep 2017 09:32:45 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      keep-alive:
+      - timeout=600
+      cache-control:
+      - public, max-age=7200
+      access-control-allow-origin:
+      - "*"
+      access-control-allow-methods:
+      - GET, POST, OPTIONS, PUT, DELETE
+      access-control-allow-credentials:
+      - 'true'
+      access-control-max-age:
+      - '604800'
+      access-control-allow-headers:
+      - Accept, Authorization, Origin, Content-Type
+      content-encoding:
+      - gzip
+      x-content-type-options:
+      - nosniff
+      strict-transport-security:
+      - max-age=31536000;
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAKxV207bQBB95yusPFPsvXjXjlRVKii0KhS1lIKoqmi9u463
+        +IYvJAHx73U2jokhdgLto2dGZ8Znzpx92DOMQZExfpMPjKHxy3ioAlWIhV4Z
+        LSLL71VkXMxTuQjXBftNNitUXrQwdFzOCpnFLByXWZiv4+lsniaF8ucaMCiK
+        NB+aZpLK+KBOHPAkMpfQppWcH8/8y/M4PrsKjqD/pbyHx/NBA/e4/9Q1yKTf
+        AmWpamHegRo278JdQ1NCY20vjFm0JOeI3SlhfEymSq7nn8jTvddTZaZ0ph5y
+        uKwY9v/0o/G7WUAP0TvSvFioCciIXtHLs9F1cDr99jU/VSENb5uGTbudGF4g
+        5l2QDVRN79ayiE3kS4EFUk2CYhEm2GoRGrbmq6bjIq5GMzWQCRiAtvQ9ShFg
+        vkOg49q271BKBRRYYB9AaHsOW1/SVIkiqFs1jGweBlmvGQYTLhimHpfCpdjm
+        nrAlF7CaENkA2YT6EBGXeBuHqVptGYbgV8ziUBsIwIQktoWZdCCB0mGIIZdC
+        VJFiSeRy2EnMBmk2Z/EjkMbXSqjGEXu6m0GXpbw4iUV62CfQWp6bzeg/XMgu
+        RvTKE9nNhHa0oH4D6rSft5hPs9+BUDkfx2XkyWwBAlbhMmOFSuJxpLmGFqEO
+        qXNyloaKK61Nn4W5bOL1hpRoLWig8ozrCS/Ov48QqBRvWaC9887t7rZb/QSa
+        4HB071z/dJzD0ck0mkz+HGeXmLcb7bLW5YPaBVcDrXyvvygfpyGbMy/Uqyuy
+        ckVWqOIbKcZ+lrTf6X+W+ZIKnHx2b2Q+n326yBz/Vp0IUp65b1N5TUcH5HOR
+        bytrZKxhu1Ws08O+/1ittM+gBmmSliHLVKFpw3gVzuSdktPxcztNGzuNUvSu
+        rjIdyxUcQY6pi4GFCfM9x7MEowRW3s6Q8EFlu5h84Eq8txkH1XsAmUB25cCM
+        VW4MiYsEQp7nOo029A9uOL2NBHXQ06346sL3Hv8CAAD//wMArM9NtB8KAAA=
+    http_version: '1.1'
+  recorded_at: Thu, 28 Sep 2017 09:32:45 GMT
+recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/track_find_6fi8e1nv4QBqODf9puRcyX_market_ES.yml
+++ b/spec/vcr_cassettes/track_find_6fi8e1nv4QBqODf9puRcyX_market_ES.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.spotify.com/v1/tracks/6fi8e1nv4QBqODf9puRcyX?market=ES
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.1.0 x86_64) ruby/2.3.0p0
+      Authorization:
+      - Bearer BQAc-gDga9IQnNv4F3XMrZFixYmmlSYqSRrIumnNQDJPREtG6P5VgC1KTIBSuoKqXr2KBe6weG5z2Ui81K8qJA
+      Host:
+      - api.spotify.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 04 Nov 2017 23:34:47 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - timeout=600
+      Cache-Control:
+      - public, max-age=7200
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, OPTIONS, PUT, DELETE
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Max-Age:
+      - '604800'
+      Access-Control-Allow-Headers:
+      - Accept, Authorization, Origin, Content-Type
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAKRUy27bMBC89ysEn4OIpCRa8i1B0gAp8ujj0KYoDIpaxYT1
+        Ckk5dYP8eyWKjuzUihX0qJ3F7HJmtE8fHGfCsrjOJ87MeWq+Nt9zva6gLVr4
+        yGJSC6VVC/y0/U0VfmuQBcvmtcxUz2QwVZVapGtDtdC6UjPXLSsoji1wzMvc
+        7WjdqT6JzgFiGi6X4iK6lqv6Ty4mluz5aDNvISHdIWSV2OFbYUuphjhfuERi
+        mA61FSzv5DjRZa6cj6V0boFx6Dt6wczkHqilMHW74KzDZ2899tn5ZQUflHak
+        sK15Lk0u787urq6T09s7ecmvV8E0Pn+wo+ygUZq2bGqIzhJZQQ805eweXsdo
+        AeJ+odsi9dGWfNnOXs1WPCmalVxD4voxS1kU+iwJUjyNcJBywDwBjFGIPMrx
+        NKQRcNIb8igSvbBjrAb7lvDQ+CUaJoxxgiNKU4zDkGAaEUIghRBTSDGC6RQi
+        D+1ZohnzxhLUH70D+B7iEPqIRM17QxqnAeEk9jmCKIwCQnzkkQCle4V4Fbs+
+        7lc3nzam7T8J/8S7BWfDkTOB23dI/jvrh4/Iu8I+5oCMOh+HjsfA6Xj/4bD+
+        TRKh+Lyo8xhkS4C7Yi2ZFmUxz422Hgl93zMI/K4ywYXJW8oyBbZq3RDJlhkT
+        oSQ3W12c+j8uMEEI4aD3dcDDcQ5qyfjSpakIARcr//Ppw81ZGlX1F77+3o8Y
+        Y55hUkNUhmZzp95qUfMqY2sWZ7CrzYuhX3XNl8638h70AhpXBfDmrJmeqqzq
+        jEmhzaNRV5OwEvA4t79yUWeZqUtQWgre2rMtmgSmysIMyplcgu5FMA/c8ph2
+        1U2QDNzt8TpFBpoNifz8FwAA//8DANLj9hoTCAAA
+    http_version:
+  recorded_at: Sat, 04 Nov 2017 23:34:47 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
This PR adds a few features from the web API for finding tracks which are playable in specific markets. This is my first PR for rspotify (thanks so much for building it!) so let me know if there's anything I need to change.

Several of the Spotify endpoints accept a market parameter, which instructs the API to perform [track relinking](https://developer.spotify.com/web-api/track-relinking-guide/) so that the response contains versions of tracks which are playable in the given market.

rspotify already supports the market parameter when fetching playlists. I've added the same parameter to the track, album and album tracks endpoints.

Note that the client needs to specify the market with every request. For example, if you fetch an album with a market and call `album.tracks`, you need to pass the market to the `tracks` method as well. The alternative would be to store the market details in the album object, but I did it this way to be consistent with the existing playlist endpoint. Does it look OK to you?

I've also added a couple of track properties associated with markets and track linking:
- `is_playable`, a boolean specifying whether the track is available in the specified market
- `linked_from`, an object with details of the track that was requested if it's different from the version of the track that is actually returned

The first two commits are just regression tests for existing features that I was building on - I think they're useful to keep, but I can remove them if you prefer.