### PR TITLE
Rescue from base RestClient exception class in oauth_send

### DIFF
--- a/lib/rspotify/user.rb
+++ b/lib/rspotify/user.rb
@@ -53,7 +53,7 @@ module RSpotify
 
     def self.oauth_send(user_id, verb, path, *params)
       RSpotify.send(:send_request, verb, path, *params)
-    rescue RestClient::Unauthorized => e
+    rescue RestClient::Exception => e
       raise e if e.response !~ /access token expired/
       refresh_token(user_id)
       params[-1] = oauth_header(user_id)


### PR DESCRIPTION
Looks like Spotify might have changed the status code returned when you try to make authenticated requests, as reported in https://github.com/guilhermesad/rspotify/issues/142

Modifies the `oauth_send` method to rescue from the `RestClient::Exception` base class