### PR TITLE
Changed currently_playing to return nil if the response does not contain an item.

### DIFF
--- a/lib/rspotify/user.rb
+++ b/lib/rspotify/user.rb
@@ -118,6 +118,7 @@ module RSpotify
     def currently_playing
       url = "me/player/currently-playing"
       response = RSpotify.resolve_auth_request(@id, url)
+      return nil unless response && response['item'].nil?
       return response if RSpotify.raw_response
       Track.new response["item"]
     end


### PR DESCRIPTION
Ran in to problems where using currently playing would result in `undefined method '[]' for nil:NilClass` error if no track was being played.

This appears to resolve that problem and enabled the ability to check for nil when getting the current track.