### PR TITLE
Allow direct access to client token

### DIFF
--- a/lib/rspotify/connection.rb
+++ b/lib/rspotify/connection.rb
@@ -56,6 +56,7 @@ module RSpotify
       url = path.start_with?('http') ? path : API_URI + path
 
       url, query = *url.split('?')
+      url = URI::encode(url)
       url << "?#{query}" if query
 
       begin

--- a/lib/rspotify/connection.rb
+++ b/lib/rspotify/connection.rb
@@ -11,6 +11,7 @@ module RSpotify
 
   class << self
     attr_accessor :raw_response
+    attr_reader :client_token
 
     # Authenticates access to restricted data. Requires {https://developer.spotify.com/my-applications user credentials}
     #
@@ -32,7 +33,7 @@ module RSpotify
 
     VERBS.each do |verb|
       define_method verb do |path, *params|
-        params << { 'Authorization' => "Bearer #{@client_token}" } if @client_token
+        params << { 'Authorization' => "Bearer #{client_token}" } if client_token
         send_request(verb, path, *params)
       end
     end
@@ -55,7 +56,6 @@ module RSpotify
       url = path.start_with?('http') ? path : API_URI + path
 
       url, query = *url.split('?')
-      url = URI::encode(url)
       url << "?#{query}" if query
 
       begin

--- a/spec/authentication_helper.rb
+++ b/spec/authentication_helper.rb
@@ -1,0 +1,11 @@
+module AuthenticationHelper
+  CLIENT_SECRET = 'BQBj_AiSFlKCkNIMbCWEYjuJLl6n76QmVsHU6MGDgTUBLZqNiKZ4ALs6Kvm6ulbsW9O81JDdIHyXBndXyhUOxg'
+
+  def authenticate_client
+    client_id = '5ac1cda2ad354aeaa1ad2693d33bb98c'
+    client_secret = '155fc038a85840679b55a1822ef36b9b'
+    VCR.use_cassette('authenticate:client') do
+      RSpotify.authenticate(client_id, client_secret)
+    end
+  end
+end

--- a/spec/lib/rspotify/album_spec.rb
+++ b/spec/lib/rspotify/album_spec.rb
@@ -72,9 +72,7 @@ describe RSpotify::Album do
     let(:client_secret) { '155fc038a85840679b55a1822ef36b9b' }
 
     before(:each) do
-    VCR.use_cassette('authenticate:client') do
-        RSpotify.authenticate(client_id, client_secret)
-      end
+      authenticate_client
     end
 
     it 'should find the appropriate new releases' do
@@ -106,9 +104,7 @@ describe RSpotify::Album do
     let(:client_secret) { '155fc038a85840679b55a1822ef36b9b' }
 
     before(:each) do
-    VCR.use_cassette('authenticate:client') do
-        RSpotify.authenticate(client_id, client_secret)
-      end
+      authenticate_client
     end
 
     it 'should search for the right albums' do

--- a/spec/lib/rspotify/audio_features_spec.rb
+++ b/spec/lib/rspotify/audio_features_spec.rb
@@ -4,9 +4,7 @@ describe RSpotify::AudioFeatures do
   let(:client_secret) { '155fc038a85840679b55a1822ef36b9b' }
 
   before do
-    VCR.use_cassette('authenticate:client') do
-      RSpotify.authenticate(client_id, client_secret)
-    end
+    authenticate_client
   end
 
   describe 'AudioFeatures::find' do

--- a/spec/lib/rspotify/category_spec.rb
+++ b/spec/lib/rspotify/category_spec.rb
@@ -5,9 +5,7 @@ describe RSpotify::Category do
   let(:client_secret) { '155fc038a85840679b55a1822ef36b9b' }
 
   before do
-    VCR.use_cassette('authenticate:client') do
-      RSpotify.authenticate(client_id, client_secret)
-    end
+    authenticate_client
   end
 
   describe 'Category::find' do

--- a/spec/lib/rspotify/client_token_spec.rb
+++ b/spec/lib/rspotify/client_token_spec.rb
@@ -1,15 +1,9 @@
 describe RSpotify do
   describe '.client_token' do
     it 'should return the client_token' do
-      client_id = '5ac1cda2ad354aeaa1ad2693d33bb98c'
-      client_secret = '155fc038a85840679b55a1822ef36b9b'
-      VCR.use_cassette('authenticate:client') do
-        RSpotify.authenticate(client_id, client_secret)
-      end
+      authenticate_client
 
-      expect(RSpotify.client_token).to eq(
-        'BQBj_AiSFlKCkNIMbCWEYjuJLl6n76QmVsHU6MGDgTUBLZqNiKZ4ALs6Kvm6ulbsW9O81JDdIHyXBndXyhUOxg'
-      )
+      expect(RSpotify.client_token).to eq(AuthenticationHelper::CLIENT_SECRET)
     end
   end
 end

--- a/spec/lib/rspotify/client_token_spec.rb
+++ b/spec/lib/rspotify/client_token_spec.rb
@@ -1,0 +1,15 @@
+describe RSpotify do
+  describe '.client_token' do
+    it 'should return the client_token' do
+      client_id = '5ac1cda2ad354aeaa1ad2693d33bb98c'
+      client_secret = '155fc038a85840679b55a1822ef36b9b'
+      VCR.use_cassette('authenticate:client') do
+        RSpotify.authenticate(client_id, client_secret)
+      end
+
+      expect(RSpotify.client_token).to eq(
+        'BQBj_AiSFlKCkNIMbCWEYjuJLl6n76QmVsHU6MGDgTUBLZqNiKZ4ALs6Kvm6ulbsW9O81JDdIHyXBndXyhUOxg'
+      )
+    end
+  end
+end

--- a/spec/lib/rspotify/playlist_spec.rb
+++ b/spec/lib/rspotify/playlist_spec.rb
@@ -10,9 +10,7 @@ describe RSpotify::Playlist do
   end
 
   before do
-    VCR.use_cassette('authenticate:client') do
-      RSpotify.authenticate(client_id, client_secret)
-    end
+    authenticate_client
   end
 
   describe 'Playlist::browse_featured' do

--- a/spec/lib/rspotify/recommendations_spec.rb
+++ b/spec/lib/rspotify/recommendations_spec.rb
@@ -4,9 +4,7 @@ describe RSpotify::Recommendations do
   let(:client_secret) { '155fc038a85840679b55a1822ef36b9b' }
 
   before do
-    VCR.use_cassette('authenticate:client') do
-      RSpotify.authenticate(client_id, client_secret)
-    end
+    authenticate_client
   end
 
   describe 'Recommendations::available_genre_seeds' do

--- a/spec/lib/rspotify/track_spec.rb
+++ b/spec/lib/rspotify/track_spec.rb
@@ -107,9 +107,7 @@ describe RSpotify::Track do
     let(:client_secret) { '155fc038a85840679b55a1822ef36b9b' }
 
     before do
-      VCR.use_cassette('authenticate:client') do
-        RSpotify.authenticate(client_id, client_secret)
-      end
+      authenticate_client
     end
 
     let(:track) do

--- a/spec/lib/rspotify/user_spec.rb
+++ b/spec/lib/rspotify/user_spec.rb
@@ -22,9 +22,7 @@ describe RSpotify::User do
       # Keys generated specifically for the tests. Should be removed in the future
       client_id     = '5ac1cda2ad354aeaa1ad2693d33bb98c'
       client_secret = '155fc038a85840679b55a1822ef36b9b'
-      VCR.use_cassette('authenticate:client') do
-        RSpotify.authenticate(client_id, client_secret)
-      end
+      authenticate_client
 
       playlists = VCR.use_cassette('user:wizzler:playlists:limit:20:offset:0') do
         @user.playlists

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'rspotify'
 require 'vcr'
 require 'webmock/rspec'
+require 'authentication_helper'
 
 VCR.configure do |c|
   c.cassette_library_dir = 'spec/vcr_cassettes'
@@ -9,7 +10,7 @@ end
 
 
 RSpec.configure do |config|
-
+  config.include AuthenticationHelper
   config.filter_run :focus
   config.run_all_when_everything_filtered = true
 


### PR DESCRIPTION
Problem
---

If you want to make requests through JS you will need your client token.

Solution
---

- Make the client token readable after authentication

Other Changes
---
- Add an authentication helper to DRY up tests