### PR TITLE
Use refreshed access_token after refreshing user access tokens

### DIFF
--- a/lib/rspotify/user.rb
+++ b/lib/rspotify/user.rb
@@ -67,7 +67,7 @@ module RSpotify
     rescue RestClient::Exception => e
       raise e if e.response !~ /access token expired/
       refresh_token(user_id)
-      params[-1] = headers
+      params[-1] = oauth_header(user_id).merge(custom_headers)
       RSpotify.send(:send_request, verb, path, *params)
     end
     private_class_method :oauth_header


### PR DESCRIPTION
Hi! I have use this library and I want to say thank you.

I encountered #142, #148

I found that retry-request of user_authenticated request doesn't use refreshed access token.
So I fixed it.

Please review it. Thanks.
