### PR TITLE
Add support for the player seek endpoint

### DIFF
--- a/lib/rspotify/player.rb
+++ b/lib/rspotify/player.rb
@@ -96,5 +96,10 @@ module RSpotify
       return response if RSpotify.raw_response
       Track.new response["item"]
     end
+
+    def seek(position_ms)
+      url = "/me/player/seek?position_ms=#{position_ms}"
+      User.oauth_put(@user.id, url, {})
+    end
   end
 end


### PR DESCRIPTION
Hey @guilhermesad, RSpotify is awesome!  Thanks for building it!

With this PR I'd like to add support for the "seek" endpoint: https://developer.spotify.com/documentation/web-api/reference/player/seek-to-position-in-currently-playing-track/

Please check it out, thanks!