### PR TITLE
Fix content-type header for Playlist#add_tracks.

### DIFF
--- a/lib/rspotify/playlist.rb
+++ b/lib/rspotify/playlist.rb
@@ -141,7 +141,7 @@ module RSpotify
       url = "#{@path}/tracks?uris=#{track_uris}"
       url << "&position=#{position}" if position
 
-      response = User.oauth_post(@owner.id, url, {})
+      response = User.oauth_post(@owner.id, url, {}.to_json)
       @total += tracks.size
       @tracks_cache = nil
 
@@ -340,7 +340,7 @@ module RSpotify
       self
     end
 
-    # Replace the image used to represent a specific playlist. Requires ugc-image-upload scope. Changing a public playlist 
+    # Replace the image used to represent a specific playlist. Requires ugc-image-upload scope. Changing a public playlist
     # requires the *playlist-modify-public* scope; changing a private playlist requires the *playlist-modify-private* scope.
     #
     # @param image [String] Base64 encoded JPEG image data, maximum payload size is 256 KB


### PR DESCRIPTION
When adding a track to a playlist I was getting the following warning

> warning: Overriding "Content-Type" header "application/json" with "application/x-www-form-urlencoded" due to payload

It looks like `RestClient` assumed that an empty hash should have been form encoded rather than JSON encoded and showed this warning. Explicitly turning the empty params hash `to_json` quietened down the warning and meant that the API calls were being made with the correct Content-Type.