### PR TITLE
Sending Accept-Language header

### DIFF
--- a/lib/rspotify/connection.rb
+++ b/lib/rspotify/connection.rb
@@ -59,6 +59,8 @@ module RSpotify
       url << "?#{query}" if query
 
       begin
+        obj = params.find{|x| x.is_a?(Hash) && x['Authorization']}
+        obj['Accept-Language'] = ENV['ACCEPT_LANGUAGE'] if ENV['ACCEPT_LANGUAGE']
         response = RestClient.send(verb, url, *params)
       rescue RestClient::Unauthorized => e
         raise e if request_was_user_authenticated?(*params)


### PR DESCRIPTION
For Japanese users, if it is necessary to return the artist name etc. in Japanese, the request header "Accept-Language" must be sent.
We implemented the setting from the environment variable, but we considered it.