### PR TITLE
remove '/' before before path to seek endpoint

### DIFF
--- a/lib/rspotify/player.rb
+++ b/lib/rspotify/player.rb
@@ -98,7 +98,7 @@ module RSpotify
     end
 
     def seek(position_ms)
-      url = "/me/player/seek?position_ms=#{position_ms}"
+      url = "me/player/seek?position_ms=#{position_ms}"
       User.oauth_put(@user.id, url, {})
     end
   end


### PR DESCRIPTION
currently this method is returning a RestClient::NotFound: 404 Not Found