### PR TITLE
Update omniauth-oauth2 dependency

### DIFF
--- a/rspotify.gemspec
+++ b/rspotify.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(/^spec\//)
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'omniauth-oauth2', '~> 1.3.1'
+  spec.add_dependency 'omniauth-oauth2', '~> 1.5.0'
   spec.add_dependency 'rest-client', '~> 2.0.2'
 
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
* Fix issue where `rspotify` is used alongside other gems which depend on newer versions of `omniauth-oauth2`
* Fixes #87 