### PR TITLE
More elegant handling of refresh of the access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,8 +219,8 @@ end
 
 ## Refreshing the access token
 
-The user's access token is automatically refreshed by RSpotify when needed. This is specially useful if you persist
-the user data on a database: this way the user only need log in to Spotify once during the use of your application.
+The user's access token is automatically refreshed by RSpotify when needed. This is especially useful if you persist
+the user data on a database. This way, the user only need log in to Spotify once during the use of the application.
 
 RSpotify provides a way to facilitate persistence:
 
@@ -235,9 +235,6 @@ spotify_user = RSpotify::User.new(hash)
 spotify_user.create_playlist!('my_awesome_playlist') # automatically refreshes token
 ```
 
-## Getting raw response
-
-To get the raw response from Spotify API requests, just toggle the `raw_response` variable:
 
 ```ruby
 RSpotify.raw_response = true
@@ -273,6 +270,10 @@ spotify_user = RSpotify::User.new(
 
 
 ```
+
+## Getting raw response
+
+To get the raw response from Spotify API requests, just toggle the `raw_response` variable:
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -222,26 +222,7 @@ end
 The user's access token is automatically refreshed by RSpotify when needed. This is especially useful if you persist
 the user data on a database. This way, the user only need log in to Spotify once during the use of the application.
 
-RSpotify provides a way to facilitate persistence:
-
-```ruby
-hash = spotify_user.to_hash
-# hash containing all user attributes, including access tokens
-
-# Use the hash to persist the data the way you prefer...
-
-# Then recover the Spotify user whenever you like
-spotify_user = RSpotify::User.new(hash)
-spotify_user.create_playlist!('my_awesome_playlist') # automatically refreshes token
-```
-
-
-```ruby
-RSpotify.raw_response = true
-RSpotify::Artist.search('Cher') #=> (String with raw json response)
-```
-
-Alternately, you can store a proc that is invoked when a new access token is generated. This give you the
+Additionally, you can store a proc that is invoked when a new access token is generated. This give you the
 opportunity to persist the new access token for future use. The proc will be invoked with two arguments: the
 new access token and the lifetime of the token in seconds. For example, if lifetime value returned from
 Spotify is 3600, you know that the token will be good for one hour.
@@ -271,9 +252,28 @@ spotify_user = RSpotify::User.new(
 
 ```
 
+RSpotify provides a way to facilitate persistence:
+
+```ruby
+hash = spotify_user.to_hash
+# hash containing all user attributes, including access tokens
+
+# Use the hash to persist the data the way you prefer...
+
+# Then recover the Spotify user whenever you like
+spotify_user = RSpotify::User.new(hash)
+spotify_user.create_playlist!('my_awesome_playlist') # automatically refreshes token
+```
+
+
 ## Getting raw response
 
 To get the raw response from Spotify API requests, just toggle the `raw_response` variable:
+
+```ruby
+RSpotify.raw_response = true
+RSpotify::Artist.search('Cher') #=> (String with raw json response)
+```
 
 ## Notes
 

--- a/lib/rspotify/user.rb
+++ b/lib/rspotify/user.rb
@@ -38,7 +38,7 @@ module RSpotify
       response = RestClient.post(TOKEN_URI, request_body, RSpotify.send(:auth_header))
       response = JSON.parse(response)
       @@users_credentials[user_id]['token'] = response['access_token']
-      proc = @@users_credentials[user_id]['access_refresh_callback']
+      access_refresh_proc = @@users_credentials[user_id]['access_refresh_callback']
       # If the access token expires and a new one is granted via the refresh
       # token, then this proc will be called with two parameters:
       # new_access_token and token_lifetime (in seconds)

--- a/lib/rspotify/user.rb
+++ b/lib/rspotify/user.rb
@@ -46,7 +46,7 @@ module RSpotify
       # such as persisting the new access token somewhere, when the new token
       # is generated.
       if (!proc.nil?)
-        proc.call(response['access_token'], response['expires_in'])
+        access_refresh_proc.call(response['access_token'], response['expires_in'])
       end
     rescue RestClient::BadRequest => e
       raise e if e.response !~ /Refresh token revoked/

--- a/lib/rspotify/user.rb
+++ b/lib/rspotify/user.rb
@@ -45,7 +45,7 @@ module RSpotify
       # The purpose is to allow the calling environment to invoke some action,
       # such as persisting the new access token somewhere, when the new token
       # is generated.
-      if (!proc.nil?)
+      if (access_refresh_proc.respond_to? :call)
         access_refresh_proc.call(response['access_token'], response['expires_in'])
       end
     rescue RestClient::BadRequest => e


### PR DESCRIPTION
Added new functionality to the User class to enable more elegant handling of refresh of the access token. The User class now has the option to store a Proc in @@users_credentials[user_id]['access_refresh_callback']. The Proc must accept two parameters. If the access token is refreshed, them the Proc will be called. The new token and the lifetime (in seconds) of the token will be passed as arguments.