### PR TITLE
update callback url to not include query params and give the option of configuring the url

### DIFF
--- a/lib/rspotify/oauth.rb
+++ b/lib/rspotify/oauth.rb
@@ -15,6 +15,16 @@ module OmniAuth
 
       info { raw_info }
 
+      def callback_url
+        if @authorization_code_from_signed_request_in_cookie
+          ''
+        else
+          # Fixes regression in omniauth-oauth2 v1.4.0 by https://github.com/intridea/omniauth-oauth2/commit/85fdbe117c2a4400d001a6368cc359d88f40abc7
+          # Spotify returns "Invalid redirect URI" if the `redirect_url` contains a query string
+          options[:callback_url] || (full_host + script_name + callback_path)
+        end
+      end
+
       def raw_info
         @raw_info ||= access_token.get('me').parsed
       end


### PR DESCRIPTION
# Fix Invalid redirect URI caused by query params

If a `redirect_url` doesn't **exactly** match what you have entered Spotify returns:
```json
{"error":"invalid_grant","error_description":"Invalid redirect URI"}):
```

This is happening because the query params are included in the `redirect_url` causing it to be different each time and making it impossible to enter it beforehand on their dashboard
e.g. the following is being sent as part of the POST data in the request to `https://accounts.spotify.com/api/token`
```
redirect_uri=http://example.com/auth/spotify/callback?code=BQCXvFP5i2xtD2XG1Ns4wowvnljaXceMrfwKK9f7yapWsqaRbf_ve0iu8Ep6ssnYh3DxC-CrujAATOgrw34JHv91zpkkWKxvTDfgZvYq1k5WG0Gakw4po9wQpP0Xe6XD6EJg5GeC4JnlgmOO2nEREYwieUcw92LoTXf8ADMW9N2VNsWhBuYpFXKGxCrjretzOvxDn2BJswqFvGpkGnFwzxFDFMc3sgmUzUoIJR6BG9dF3N...
```
instead of just
```
redirect_uri=http://example.com/auth/spotify/callback
```

This fix is based on:
https://github.com/icoretech/omniauth-spotify/blob/a6b6ccc6ee1b0c3b90ede44efc928628f4b04420/lib/omniauth-spotify.rb#L81-L88


Another solution would be to remove this file altogether and just make [`omniauth-spotify`](https://github.com/icoretech/omniauth-spotify) a dependency