### PR TITLE
Keep pagination fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,16 @@ RSpotify.raw_response = true
 RSpotify::Artist.search('Cher') #=> (String with raw json response)
 ```
 
+## Getting pagination info
+
+To get the pagination info from Spotify API requests, just toggle the `pagination_info` variable:  
+
+
+```ruby
+RSpotify.pagination_info = true
+RSpotify::Artist.search('Cher') #=> (String with raw json response)
+```
+
 ## Notes
 
 If you'd like to use OAuth outside rails, have a look [here](https://developer.spotify.com/web-api/authorization-guide/#authorization_code_flow) for the requests that need to be made. You should be able to pass the response to RSpotify::User.new just as well, and from there easily create playlists and more for your user.

--- a/lib/rspotify/connection.rb
+++ b/lib/rspotify/connection.rb
@@ -13,6 +13,7 @@ module RSpotify
 
   class << self
     attr_accessor :raw_response
+    attr_accessor :pagination_info
     attr_reader :client_token
 
     # Authenticates access to restricted data. Requires {https://developer.spotify.com/my-applications user credentials}

--- a/lib/rspotify/user.rb
+++ b/lib/rspotify/user.rb
@@ -263,7 +263,10 @@ module RSpotify
       url = "users/#{@id}/playlists?limit=#{limit}&offset=#{offset}"
       response = RSpotify.resolve_auth_request(@id, url)
       return response if RSpotify.raw_response
-      response['items'].map { |i| Playlist.new i }
+      result = response
+      result['items'] = response['items'].map { |i| Playlist.new i }
+      return result if RSpotify.pagination_info
+      result['items']
     end
 
     # Remove tracks from the user’s “Your Music” library.


### PR DESCRIPTION
I'm using this gem in a personal project where I need to have the pagination details for the playlists in the results but the current version of the app is stripping them away.

I've kept backward compatibility with the current implementation of the gem by setting a flag to activate the pagination.

This PR is mainly to ask the maintainers opinion on the implementation if approved I'm planning to do the same to the rest of the requests.

(the commit is from last year because I parked my project with the intent to open this PR and now I'm picking it up again)