### PR TITLE
Fix user.player

### DIFF
--- a/lib/rspotify/user.rb
+++ b/lib/rspotify/user.rb
@@ -139,7 +139,7 @@ module RSpotify
       url = "me/player"
       response = User.oauth_get(@id, url)
       return response if RSpotify.raw_response
-      response.present? ? Player.new(self, response) : nil
+      response ? Player.new(self, response) : Player.new(self)
     end
 
     # Get the current user’s recently played tracks. Requires the *user-read-recently-played* scope.


### PR DESCRIPTION
When doing `user.player`, I'm getting the error `NoMethodError: undefined method `present?' for #<Hash:0x00007fe2eff07650>`. Since no other method seems to be using this check before parsing the response, I'm suggesting its removal.