### PR TITLE
Update Playlist#replace_tracks! request headers

### DIFF
--- a/lib/rspotify/playlist.rb
+++ b/lib/rspotify/playlist.rb
@@ -390,7 +390,7 @@ module RSpotify
     def replace_tracks!(tracks)
       track_uris = tracks.map(&:uri).join(',')
       url = "#{@path}/tracks?uris=#{track_uris}"
-      User.oauth_put(@owner.id, url, {})
+      User.oauth_put(@owner.id, url, {}.to_json)
 
       @total = tracks.size
       @tracks_cache = nil


### PR DESCRIPTION
When add a bulk of track to be replaces we get a warning of the replacement of the `Content-type` header by RestClient.

Related: [PR#168](https://github.com/guilhermesad/rspotify/pull/168)