### PR TITLE
Retry Requests Even If Client Token Was Not Present Initially

### DIFF
--- a/lib/rspotify/connection.rb
+++ b/lib/rspotify/connection.rb
@@ -67,7 +67,7 @@ module RSpotify
       rescue RestClient::Unauthorized => e
         raise e if request_was_user_authenticated?(*params)
 
-        raise MissingAuthentication unless @client_token
+        raise MissingAuthentication unless @client_id && @client_secret
 
         authenticate(@client_id, @client_secret)
 


### PR DESCRIPTION
Hey @guilhermesad thanks for developing this awesome gem. I found an scenario where the retry mechanism was failing. This is when the initial authorization call that retrieves the `client_token` fails. I changed it so that it doesn't require the `client_token` (but the `client_id` and `client_secret` instead) to be set in order to retry a request.

By the way, I switched to use my fork (with this change) on production and it's working nicely.