### PR TITLE
Store json response in Base

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,13 @@ RSpotify.raw_response = true
 RSpotify::Artist.search('Cher') #=> (String with raw json response)
 ```
 
+Alternatively, if you still need access to the RSpotify objects you can access
+it via the `json` attribute:
+
+```ruby
+RSpotify::Artist.search('Cher').json #=> (Hash of the json response)
+```
+
 ## Notes
 
 If you'd like to use OAuth outside rails, have a look [here](https://developer.spotify.com/web-api/authorization-guide/#authorization_code_flow) for the requests that need to be made. You should be able to pass the response to RSpotify::User.new just as well, and from there easily create playlists and more for your user.

--- a/lib/rspotify/base.rb
+++ b/lib/rspotify/base.rb
@@ -5,6 +5,7 @@ module RSpotify
   # @attr [String] id            The {https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids Spotify ID} for the object
   # @attr [String] type          The object type (artist, album, etc.)
   # @attr [String] uri           The {https://developer.spotify.com/web-api/user-guide/#spotify-uris-and-ids Spotify URI} for the object
+  # @attr [Hash]   json          The JSON response received for this object
   class Base
 
     # Returns RSpotify object(s) with id(s) and type provided
@@ -121,6 +122,7 @@ module RSpotify
       @id            = options['id']
       @type          = options['type']
       @uri           = options['uri']
+      @json          = options
     end
 
     # Generate an embed code for an album, artist or track.

--- a/lib/rspotify/user.rb
+++ b/lib/rspotify/user.rb
@@ -38,8 +38,8 @@ module RSpotify
       response = RestClient.post(TOKEN_URI, request_body, RSpotify.send(:auth_header))
       response = JSON.parse(response)
       @@users_credentials[user_id]['token'] = response['access_token']
-    rescue RestClient::BadRequest => e
-      raise e if e.response !~ /Refresh token revoked/
+    # rescue RestClient::Unauthorized => e
+    #   raise e if e.response !~ /Refresh token revoked/
     end
     private_class_method :refresh_token
 


### PR DESCRIPTION
This allows the JSON response returned from spotify to be accessed across all objects by storing it in the Base object. This was useful for our use case where we needed to get access to the underlying json blob, but still wanted to still be able to use the handy underlying rspotify methods. `RSpotify.raw_response = true` only returns the hashes. Not sure how this affects memory performance etc.