### PR TITLE
[Fix] Upgrade Addressable gem version to fix URI obsolete warning in ruby 2.7+

### DIFF
--- a/rspotify.gemspec
+++ b/rspotify.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'omniauth-oauth2', '>= 1.6'
   spec.add_dependency 'rest-client', '~> 2.0.2'
-  spec.add_dependency 'addressable', '~> 2.5.2'
+  spec.add_dependency 'addressable', '~> 2.7.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'webmock'


### PR DESCRIPTION
"warning: URI.escape is obsolete"
All requests in ruby 2.7 are getting this warning.

The 'new' way of doing it is: URI.encode_www_form_component(url)
but it encodes the http:// as well...
As we already use the Addressable Gem, upgrading to 2.7.0 it is the fastest way to solve the issue.
more info about URI.encode/escape: https://docs.knapsackpro.com/2020/uri-escape-is-obsolete-percent-encoding-your-query-string