### PR TITLE
Relax addressable dependency to allow 2.6+.

### DIFF
--- a/rspotify.gemspec
+++ b/rspotify.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'omniauth-oauth2', '>= 1.6'
   spec.add_dependency 'rest-client', '~> 2.0.2'
-  spec.add_dependency 'addressable', '~> 2.5.2'
+  spec.add_dependency 'addressable', '>= 2.5.2'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'webmock'


### PR DESCRIPTION
A small step beyond #228 - Addressable v2.8.0 has a security patch, so this change allows v2.5.2 or newer to be used. Tests all passed on my machine FWIW.