### PR TITLE
Update Addressable to v2.8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .bundle
+.idea
+.rakeTasks
 .yardoc
 doc
 pkg

--- a/rspotify.gemspec
+++ b/rspotify.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'omniauth-oauth2', '>= 1.6'
   spec.add_dependency 'rest-client', '~> 2.0.2'
-  spec.add_dependency 'addressable', '~> 2.5.2'
+  spec.add_dependency 'addressable', '~> 2.8.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'webmock'


### PR DESCRIPTION
There a security vulnerability in Addressable v2.7.0 or earlier: https://github.com/advisories/GHSA-jxhc-q857-3j6g