### PR TITLE
Update addressable version

### DIFF
--- a/rspotify.gemspec
+++ b/rspotify.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'omniauth-oauth2', '>= 1.6'
   spec.add_dependency 'rest-client', '~> 2.0.2'
-  spec.add_dependency 'addressable', '~> 2.5.2'
+  spec.add_dependency 'addressable', '~> 2.7.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'webmock'

--- a/rspotify.gemspec
+++ b/rspotify.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'omniauth-oauth2', '>= 1.6'
   spec.add_dependency 'rest-client', '~> 2.0.2'
-  spec.add_dependency 'addressable', '~> 2.7.0'
+  spec.add_dependency 'addressable', '~> 2.8.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'webmock'


### PR DESCRIPTION
Addressable 2.7.0 has a vulnerability: https://github.com/advisories/GHSA-jxhc-q857-3j6g
Patching to version 2.8.0