### PR TITLE
Ensure consistent use of Addressable::URI.encode

### DIFF
--- a/lib/rspotify/playlist.rb
+++ b/lib/rspotify/playlist.rb
@@ -315,7 +315,7 @@ module RSpotify
 
       params = {
         method: :delete,
-        url: URI::encode(RSpotify::API_URI + @path + '/tracks'),
+        url: Addressable::URI.encode(RSpotify::API_URI + @path + '/tracks'),
         headers: User.send(:oauth_header, @owner.id),
         payload: positions ? { positions: positions } : { tracks: tracks }
       }


### PR DESCRIPTION
I was running into the issue described in [this stackoverflow thread](https://stackoverflow.com/questions/68635238/undefined-method-encode-for-urimodule-with-gem-rspotify), which was basically that when using more recent versions of ruby all API calls with rspotify would just throw `undefined method `encode' for URI:Module`.

As per the insightful suggestion by @kstrukov in the stackoverflow thread, I tried simply updating rspotify to be consistent in its use of `Addressable::URI.encode` instead of the deprecated `URI::encode`, and it seems to have solved the issue for me so figured I'd propose the change.