### PR TITLE
Add allowed_request_methods to README.md for omniauth

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ require 'rspotify/oauth'
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :spotify, "<your_client_id>", "<your_client_secret>", scope: 'user-read-email playlist-modify-public user-library-read user-library-modify'
 end
+
+OmniAuth.config.allowed_request_methods = [:post, :get]
 ```
 
 You should replace the scope values for the ones your own app will require from the user. You can see the list of available scopes in [here](https://developer.spotify.com/documentation/general/guides/authorization/scopes/).


### PR DESCRIPTION
As per https://github.com/guilhermesad/rspotify/issues/96, this is something needed to get omniauth up and running.

Alternative to https://github.com/guilhermesad/rspotify/pull/249