### PR TITLE
Fix the playlist path that could cause errors

### DIFF
--- a/lib/rspotify/playlist.rb
+++ b/lib/rspotify/playlist.rb
@@ -128,8 +128,11 @@ module RSpotify
 
       super(options)
 
-      @path = "users/#{@owner.instance_variable_get('@id').gsub('?','')}/"
-      @path << (@href =~ /\/starred$/ ? 'starred' : "playlists/#{@id}")
+      @path = if @href =~ /\/starred$/ 
+        "users/#{@owner.instance_variable_get('@id').gsub('?','')}/starred" 
+      else
+        "playlists/#{@id}"
+      end
     end
 
     # Adds one or more tracks to a playlist in user's Spotify account. This method is only available when the


### PR DESCRIPTION
According to https://github.com/guilhermesad/rspotify/issues/167, the playlist endpoints with username were deprecated sometime ago. Although some might still work, at least the remove tracks endpoint does not work. Spotify returns 403 Forbidden when trying to do so.

This PR adjusts the playlist `@path` to not have the username on regular playlists. I tested and I got tracks removed from playlists again, using the remove by positions (some ways of removing tracks seem to not work as reliably but that might be Spotify's fault).

I didn't find much information about the starred playlist so I kept it as it was.

I'm not sure if this is the best approach but I'm open to suggestions.