### PR TITLE
Fix for playlist.add_tracks! if no credentials for the playlist owner exist

### DIFF
--- a/lib/rspotify/user.rb
+++ b/lib/rspotify/user.rb
@@ -61,8 +61,11 @@ module RSpotify
     private_class_method :extract_custom_headers
 
     def self.oauth_header(user_id)
+      token = @@users_credentials.dig(user_id, 'token')
+      # Fallback for playlist.add_tracks! if no credentials for the playlist owner exist
+      token ||= @@users_credentials.values.dig(0, 'token')
       {
-        'Authorization' => "Bearer #{@@users_credentials[user_id]['token']}",
+        'Authorization' => "Bearer #{token}",
         'Content-Type'  => 'application/json'
       }
     end


### PR DESCRIPTION
Calling `add_tracks!` causes the following exception:

```
/home/shai/.rbenv/versions/3.3.1/lib/ruby/gems/3.3.0/gems/rspotify-2.12.1/lib/rspotify/user.rb:65:in `oauth_header': undefined method `[]' for nil (NoMethodError)

        'Authorization' => "Bearer #{@@users_credentials[user_id]['token']}",
                                                                 ^^^^^^^^^
	from /home/shai/.rbenv/versions/3.3.1/lib/ruby/gems/3.3.0/gems/rspotify-2.12.1/lib/rspotify/user.rb:73:in `oauth_send'
	from /home/shai/.rbenv/versions/3.3.1/lib/ruby/gems/3.3.0/gems/rspotify-2.12.1/lib/rspotify/user.rb:87:in `block (2 levels) in <class:User>'
	from /home/shai/.rbenv/versions/3.3.1/lib/ruby/gems/3.3.0/gems/rspotify-2.12.1/lib/rspotify/playlist.rb:165:in `add_tracks!'	
```

This is because the `add_tracks!` tries to use the credentials of the playlist owner, instead of the current user's credentials.
https://github.com/guilhermesad/rspotify/blob/0a95a52e1b2bbfbed65ff4b8cffee12beec74623/lib/rspotify/playlist.rb#L165

If the credentials for the users are not found, it will fall back to the first token.

Properly fixing it requires a breaking change, as you need to pass the user to the playlist, but this will fix it for most cases.