### PR TITLE
Fix issue that has popped up with play/pause

### DIFF
--- a/lib/rspotify/connection.rb
+++ b/lib/rspotify/connection.rb
@@ -78,7 +78,12 @@ module RSpotify
       end
 
       return response if raw_response
-      JSON.parse(response) unless response.nil? || response.empty?
+
+      begin
+        JSON.parse(response) unless response.nil? || response.empty?
+      rescue JSON::ParserError, TypeError => e
+        response.to_s # Fall back to raw body when the response is not actually a valid JSON response
+      end
     end
 
     # Added this method for testing


### PR DESCRIPTION
For some reason calling play/pause on the player has started returning what appears to be an id, or some other hashed value.

This causes a JSON parsing exception.  I struggled to find any documentation on this change, but for the time being, I caught the error and simply return the raw body so at least it doesn't error.  

At the moment nothing seems to be done with this response, so hopefully this is enough for now. It at least makes the actions work without causing errors stopping execution