### PR TITLE
Fix request for User#save_tracks!

### DIFF
--- a/lib/rspotify/user.rb
+++ b/lib/rspotify/user.rb
@@ -317,8 +317,8 @@ module RSpotify
     def save_tracks!(tracks)
       tracks_ids = tracks.map(&:id)
       url = "me/tracks"
-      request_body = tracks_ids.inspect
-      User.oauth_put(@id, url, request_body)
+      request_body = { ids: tracks_ids }
+      User.oauth_put(@id, url, request_body.to_json)
       tracks
     end
 


### PR DESCRIPTION
According to the [Spotify API Documentation](https://developer.spotify.com/documentation/web-api/reference/save-tracks-user) the request body for `PUT /me/tracks` should look like this:
```json
{
    "ids": ["track_id"]
}
````	

But RSpotify was making a request with a body like this:
```json
["track_id"]
```

Somehow that format still worked, but at least since 29.09.2024 Spotify returns a `400 Bad Request`, so this PR changes the request body to the new format